### PR TITLE
Fix n choose k bug

### DIFF
--- a/game/calculated_npc.go
+++ b/game/calculated_npc.go
@@ -36,18 +36,23 @@ func (npc *calcNPCInteraction) AskToShuffle() bool {
 }
 
 func (npc *calcNPCInteraction) AskForCribCards(dealerColor model.PlayerColor, desired int, hand []model.Card) []model.Card {
+	// shouldn't dogsled the errors here, but also shouldn't redefine the interface. This code is going away soon anyway :/
 	if dealerColor == npc.myColor {
 		if rand.Int()%2 == 0 {
 			// We might not want this, but it is a form of calculation
-			return strategy.KeepHandLowestPotential(desired, hand)
+			cards, _ := strategy.KeepHandLowestPotential(desired, hand)
+			return cards
 		}
-		return strategy.GiveCribHighestPotential(desired, hand)
+		cards, _ := strategy.GiveCribHighestPotential(desired, hand)
+		return cards
 	}
 
 	if rand.Int()%2 == 0 {
-		return strategy.KeepHandHighestPotential(desired, hand)
+		cards, _ := strategy.KeepHandHighestPotential(desired, hand)
+		return cards
 	}
-	return strategy.GiveCribLowestPotential(desired, hand)
+	cards, _ := strategy.GiveCribLowestPotential(desired, hand)
+	return cards
 }
 
 func (npc *calcNPCInteraction) AskForCut() float64 {

--- a/logic/strategy/calculated_crib.go
+++ b/logic/strategy/calculated_crib.go
@@ -26,7 +26,10 @@ func getBestPotentialCrib(hand []model.Card, isBetter func(old, new float64) boo
 	bestCrib := make([]model.Card, 0, lenDeposit)
 	bestPotential := 0.0
 
-	allDeposits := chooseFrom(lenDeposit, hand)
+	allDeposits, err := chooseFrom(lenDeposit, hand)
+	if err != nil {
+		//TODO do something
+	}
 
 	seen := map[model.Card]struct{}{}
 	for _, c := range hand {

--- a/logic/strategy/calculated_crib.go
+++ b/logic/strategy/calculated_crib.go
@@ -21,7 +21,7 @@ func GiveCribLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
 
 func getBestPotentialCrib(hand []model.Card, isBetter func(old, new float64) bool) ([]model.Card, error) {
 	if len(hand) > 6 || len(hand) <= 4 {
-		return nil, errors.New(`invalid input`)
+		return nil, errors.New(`hand size must be between 4 and 6`)
 	}
 
 	lenDeposit := len(hand) - 4

--- a/logic/strategy/calculated_crib.go
+++ b/logic/strategy/calculated_crib.go
@@ -1,25 +1,27 @@
 package strategy
 
 import (
+	"errors"
+
 	"github.com/joshprzybyszewski/cribbage/logic/scorer"
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
 // GiveCribHighestPotential gives the crib the highest potential pointed crib
-func GiveCribHighestPotential(_ int, hand []model.Card) []model.Card {
+func GiveCribHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
 	isBetter := func(old, new float64) bool { return new > old }
 	return getBestPotentialCrib(hand, isBetter)
 }
 
 // GiveCribLowestPotential gives the crib the lowest potential pointed hand
-func GiveCribLowestPotential(_ int, hand []model.Card) []model.Card {
+func GiveCribLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
 	isBetter := func(old, new float64) bool { return new < old }
 	return getBestPotentialCrib(hand, isBetter)
 }
 
-func getBestPotentialCrib(hand []model.Card, isBetter func(old, new float64) bool) []model.Card {
+func getBestPotentialCrib(hand []model.Card, isBetter func(old, new float64) bool) ([]model.Card, error) {
 	if len(hand) > 6 || len(hand) <= 4 {
-		return nil
+		return nil, errors.New(`invalid input`)
 	}
 
 	lenDeposit := len(hand) - 4
@@ -28,7 +30,7 @@ func getBestPotentialCrib(hand []model.Card, isBetter func(old, new float64) boo
 
 	allDeposits, err := chooseFrom(lenDeposit, hand)
 	if err != nil {
-		//TODO do something
+		return nil, err
 	}
 
 	seen := map[model.Card]struct{}{}
@@ -45,7 +47,7 @@ func getBestPotentialCrib(hand []model.Card, isBetter func(old, new float64) boo
 		}
 	}
 
-	return bestCrib
+	return bestCrib, nil
 }
 
 func getPotentialForDeposit(prevSeen map[model.Card]struct{}, cribDeposit []model.Card) float64 {

--- a/logic/strategy/calculated_crib_test.go
+++ b/logic/strategy/calculated_crib_test.go
@@ -25,7 +25,8 @@ func TestGiveCribHighestPotential(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		actHand := GiveCribHighestPotential(tc.inputDesired, strToCards(tc.inputHand))
+		actHand, err := GiveCribHighestPotential(tc.inputDesired, strToCards(tc.inputHand))
+		assert.Nil(t, err)
 		for _, c := range actHand {
 			assert.True(t, containsCard(tc.inputHand, c), tc.msg+`: unexpected card `+c.String())
 		}
@@ -52,7 +53,8 @@ func TestGiveCribLowestPotential(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		actHand := GiveCribLowestPotential(tc.inputDesired, strToCards(tc.inputHand))
+		actHand, err := GiveCribLowestPotential(tc.inputDesired, strToCards(tc.inputHand))
+		assert.Nil(t, err)
 		for _, c := range actHand {
 			assert.True(t, containsCard(tc.inputHand, c), tc.msg+`: unexpected card `+c.String())
 		}

--- a/logic/strategy/calculated_hand.go
+++ b/logic/strategy/calculated_hand.go
@@ -25,7 +25,10 @@ func getBestPotentialHand(hand []model.Card, isBetter func(old, new float64) boo
 	bestHand := make([]model.Card, 0, 4)
 	bestPotential := 0.0
 
-	allHands := chooseFrom(4, hand)
+	allHands, err := chooseFrom(4, hand)
+	if err != nil {
+		//TODO do something
+	}
 
 	seen := map[model.Card]struct{}{}
 	for _, c := range hand {

--- a/logic/strategy/calculated_hand.go
+++ b/logic/strategy/calculated_hand.go
@@ -21,7 +21,7 @@ func KeepHandLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
 
 func getBestPotentialHand(hand []model.Card, isBetter func(old, new float64) bool) ([]model.Card, error) {
 	if len(hand) > 6 || len(hand) <= 4 {
-		return nil, errors.New(`invalid input`)
+		return nil, errors.New(`hand size must be between 4 and 6`)
 	}
 
 	bestHand := make([]model.Card, 0, 4)

--- a/logic/strategy/calculated_hand.go
+++ b/logic/strategy/calculated_hand.go
@@ -1,25 +1,27 @@
 package strategy
 
 import (
+	"errors"
+
 	"github.com/joshprzybyszewski/cribbage/logic/scorer"
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
 // KeepHandHighestPotential will keep the hand with the highest potential score
-func KeepHandHighestPotential(_ int, hand []model.Card) []model.Card {
+func KeepHandHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
 	isBetter := func(old, new float64) bool { return new > old }
 	return getBestPotentialHand(hand, isBetter)
 }
 
 // KeepHandLowestPotential will keep the hand with the lowest potential score
-func KeepHandLowestPotential(_ int, hand []model.Card) []model.Card {
+func KeepHandLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
 	isBetter := func(old, new float64) bool { return new < old }
 	return getBestPotentialHand(hand, isBetter)
 }
 
-func getBestPotentialHand(hand []model.Card, isBetter func(old, new float64) bool) []model.Card {
+func getBestPotentialHand(hand []model.Card, isBetter func(old, new float64) bool) ([]model.Card, error) {
 	if len(hand) > 6 || len(hand) <= 4 {
-		return nil
+		return nil, errors.New(`invalid input`)
 	}
 
 	bestHand := make([]model.Card, 0, 4)
@@ -27,7 +29,7 @@ func getBestPotentialHand(hand []model.Card, isBetter func(old, new float64) boo
 
 	allHands, err := chooseFrom(4, hand)
 	if err != nil {
-		//TODO do something
+		return nil, err
 	}
 
 	seen := map[model.Card]struct{}{}
@@ -44,7 +46,7 @@ func getBestPotentialHand(hand []model.Card, isBetter func(old, new float64) boo
 		}
 	}
 
-	return without(hand, bestHand)
+	return without(hand, bestHand), nil
 }
 
 func getHandPotentialForCribDeposit(prevSeen map[model.Card]struct{}, hand []model.Card) float64 {

--- a/logic/strategy/card_utils.go
+++ b/logic/strategy/card_utils.go
@@ -36,39 +36,28 @@ func otherOptions(desired int, avoid map[model.Card]struct{}) [][]model.Card {
 	return options
 }
 
-func getBitInds(num uint) []int {
-	iter := 0
-	idx := make([]int, 0)
-	for num > 0 {
-		if num&1 > 0 {
-			idx = append(idx, iter)
+func chooseFrom(k int, hand []model.Card) [][]model.Card {
+	if k == 1 {
+		all := make([][]model.Card, len(hand))
+		for i, e := range hand {
+			all[i] = []model.Card{e}
 		}
-		num >>= 1
-		iter++
+		return all
 	}
-	return idx
-}
-
-func chooseFrom(desired int, hand []model.Card) [][]model.Card {
-	if desired > len(hand) || desired > 4 || desired <= 0 {
-		return nil
+	if k == len(hand) {
+		return [][]model.Card{hand}
 	}
-	// the min int we need is the number with the lowest _n_ bits set, where n = desired
-	// the max int we need is the number with the highest _n_ bits set, where n = desired
-	// e.g. for 6 choose 4, we need min = 001111 and max = 111100
-	hands := make([][]model.Card, 0)
-	min := uint(1<<uint(desired)) - 1
-	max := min << uint(len(hand)-desired)
-	for i := min; i <= max; i++ {
-		if idx := getBitInds(i); len(idx) == desired {
-			thisHand := make([]model.Card, desired)
-			for j, k := range idx {
-				thisHand[j] = hand[k]
-			}
-			hands = append(hands, thisHand)
+	all := make([][]model.Card, 0)
+	for i := 0; i <= len(hand)-k; i++ {
+		c := hand[i]
+		others := hand[i+1:]
+		otherSets := chooseFrom(k-1, others)
+		for _, s := range otherSets {
+			set := append([]model.Card{c}, s...)
+			all = append(all, set)
 		}
 	}
-	return hands
+	return all
 }
 
 // without returns the cards in superset minus the subsetToRemove

--- a/logic/strategy/card_utils.go
+++ b/logic/strategy/card_utils.go
@@ -36,19 +36,17 @@ func otherOptions(desired int, avoid map[model.Card]struct{}) [][]model.Card {
 	return options
 }
 
-func countBits(num uint) (int, []int) {
-	n := 0
+func getBitInds(num uint) []int {
 	iter := 0
 	idx := make([]int, 0)
 	for num > 0 {
 		if num&1 > 0 {
-			n++
 			idx = append(idx, iter)
 		}
 		num >>= 1
 		iter++
 	}
-	return n, idx
+	return idx
 }
 
 func chooseFrom(desired int, hand []model.Card) [][]model.Card {
@@ -62,7 +60,7 @@ func chooseFrom(desired int, hand []model.Card) [][]model.Card {
 	min := uint(1<<uint(desired)) - 1
 	max := min << uint(len(hand)-desired)
 	for i := min; i <= max; i++ {
-		if n, idx := countBits(i); n == desired {
+		if idx := getBitInds(i); len(idx) == desired {
 			thisHand := make([]model.Card, desired)
 			for j, k := range idx {
 				thisHand[j] = hand[k]

--- a/logic/strategy/card_utils.go
+++ b/logic/strategy/card_utils.go
@@ -50,7 +50,9 @@ func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
 		return all, nil
 	}
 	if k == len(hand) {
-		return [][]model.Card{hand}, nil
+		cpy := make([]model.Card, len(hand))
+		copy(cpy, hand)
+		return [][]model.Card{cpy}, nil
 	}
 	all := make([][]model.Card, 0)
 	for i := 0; i <= len(hand)-k; i++ {

--- a/logic/strategy/card_utils.go
+++ b/logic/strategy/card_utils.go
@@ -1,6 +1,8 @@
 package strategy
 
 import (
+	"errors"
+
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
@@ -36,28 +38,34 @@ func otherOptions(desired int, avoid map[model.Card]struct{}) [][]model.Card {
 	return options
 }
 
-func chooseFrom(k int, hand []model.Card) [][]model.Card {
+func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
+	if k < 1 || k > len(hand) {
+		return nil, errors.New(`invalid input`)
+	}
 	if k == 1 {
 		all := make([][]model.Card, len(hand))
 		for i, e := range hand {
 			all[i] = []model.Card{e}
 		}
-		return all
+		return all, nil
 	}
 	if k == len(hand) {
-		return [][]model.Card{hand}
+		return [][]model.Card{hand}, nil
 	}
 	all := make([][]model.Card, 0)
 	for i := 0; i <= len(hand)-k; i++ {
 		c := hand[i]
 		others := hand[i+1:]
-		otherSets := chooseFrom(k-1, others)
+		otherSets, err := chooseFrom(k-1, others)
+		if err != nil {
+			return nil, err
+		}
 		for _, s := range otherSets {
 			set := append([]model.Card{c}, s...)
 			all = append(all, set)
 		}
 	}
-	return all
+	return all, nil
 }
 
 // without returns the cards in superset minus the subsetToRemove

--- a/logic/strategy/card_utils.go
+++ b/logic/strategy/card_utils.go
@@ -55,6 +55,8 @@ func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
 		return [][]model.Card{cpy}, nil
 	}
 	all := make([][]model.Card, 0)
+	// for the first n-k cards, recursively find combinations of length k-1 which are
+	// combined with the current card to get combinations of length k
 	for i := 0; i <= len(hand)-k; i++ {
 		c := hand[i]
 		others := hand[i+1:]

--- a/logic/strategy/card_utils.go
+++ b/logic/strategy/card_utils.go
@@ -65,7 +65,9 @@ func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
 			return nil, err
 		}
 		for _, s := range otherSets {
-			set := append([]model.Card{c}, s...)
+			set := make([]model.Card, 1, k)
+			set[0] = c
+			set = append(set, s...)
 			all = append(all, set)
 		}
 	}

--- a/logic/strategy/card_utils.go
+++ b/logic/strategy/card_utils.go
@@ -39,8 +39,11 @@ func otherOptions(desired int, avoid map[model.Card]struct{}) [][]model.Card {
 }
 
 func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
-	if len(hand) > 6 || k < 1 || k > len(hand) {
-		return nil, errors.New(`invalid input`)
+	if k < 1 || k > len(hand) {
+		return nil, errors.New(`developer error: invalid k`)
+	}
+	if len(hand) > 6 {
+		return nil, errors.New(`too many cards in hand (maximum 6)`)
 	}
 	if k == 1 {
 		all := make([][]model.Card, len(hand))

--- a/logic/strategy/card_utils.go
+++ b/logic/strategy/card_utils.go
@@ -39,7 +39,7 @@ func otherOptions(desired int, avoid map[model.Card]struct{}) [][]model.Card {
 }
 
 func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
-	if k < 1 || k > len(hand) {
+	if len(hand) > 6 || k < 1 || k > len(hand) {
 		return nil, errors.New(`invalid input`)
 	}
 	if k == 1 {
@@ -54,7 +54,8 @@ func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
 		copy(cpy, hand)
 		return [][]model.Card{cpy}, nil
 	}
-	all := make([][]model.Card, 0)
+	// 6 choose 3 = 20, the max number of combos we would ever have
+	all := make([][]model.Card, 0, 20)
 	// for the first n-k cards, recursively find combinations of length k-1 which are
 	// combined with the current card to get combinations of length k
 	for i := 0; i <= len(hand)-k; i++ {

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -13,16 +13,16 @@ import (
 func validateHand(origHand, thisHand []model.Card) bool {
 	prev := make(map[model.Card]int)
 	for i, c := range thisHand {
-		_, inMap := prev[c]
-		if inMap {
+		_, ok := prev[c]
+		if ok {
 			return false
 		}
 		prev[c] = i
 	}
 	ct := 0
 	for _, c := range origHand {
-		_, inMap := prev[c]
-		if inMap {
+		_, ok := prev[c]
+		if ok {
 			ct++
 		}
 	}
@@ -30,8 +30,8 @@ func validateHand(origHand, thisHand []model.Card) bool {
 }
 
 func factorial(n int, cache map[int]int) int {
-	res, inMap := cache[n]
-	if inMap {
+	res, ok := cache[n]
+	if ok {
 		return res
 	}
 	if n == 1 {

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -10,21 +10,7 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
-func isIn(c model.Card, h []model.Card) bool {
-	for _, thisCard := range h {
-		if c == thisCard {
-			return true
-		}
-	}
-	return false
-}
-
 func validateHand(origHand, thisHand []model.Card) bool {
-	for _, c := range thisHand {
-		if !isIn(c, origHand) {
-			return false
-		}
-	}
 	prev := make(map[model.Card]int)
 	for i, c := range thisHand {
 		_, inMap := prev[c]
@@ -33,7 +19,14 @@ func validateHand(origHand, thisHand []model.Card) bool {
 		}
 		prev[c] = i
 	}
-	return true
+	ct := 0
+	for _, c := range origHand {
+		_, inMap := prev[c]
+		if inMap {
+			ct++
+		}
+	}
+	return ct == len(thisHand)
 }
 
 func factorial(n int, cache map[int]int) int {

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -1,9 +1,11 @@
 package strategy
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/joshprzybyszewski/cribbage/model"
 )
@@ -19,11 +21,41 @@ func isIn(c model.Card, h []model.Card) bool {
 
 func validateHand(origHand, thisHand []model.Card) bool {
 	for _, c := range thisHand {
-		if isIn(c, origHand) {
-			return true
+		if !isIn(c, origHand) {
+			return false
 		}
 	}
-	return false
+	for i := 0; i < len(thisHand)-2; i++ {
+		// check that no duplicates exist in this hand
+		for _, c2 := range thisHand[i+1:] {
+			if thisHand[i] == c2 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func factorial(n int) int {
+	if n == 1 {
+		return n
+	}
+	return n * factorial(n-1)
+}
+
+func nchoosek(n, k int) (int, error) {
+	if k > n {
+		return 0, errors.New(`k must be less than or equal to n`)
+	}
+	return factorial(n) / (factorial(k) * factorial(n-k)), nil
+}
+
+func generateHand(n int) []model.Card {
+	hand := make([]model.Card, n)
+	for i := 0; i < n; i++ {
+		hand[i] = model.NewCardFromNumber(i)
+	}
+	return hand
 }
 
 func TestChooseFrom(t *testing.T) {
@@ -32,19 +64,37 @@ func TestChooseFrom(t *testing.T) {
 		hand   []model.Card
 		nCards int
 	}{{
-		desc: ``,
-		hand: []model.Card{
-			model.NewCardFromString(`ac`),
-			model.NewCardFromString(`2c`),
-			model.NewCardFromString(`3c`),
-			model.NewCardFromString(`4c`),
-			model.NewCardFromString(`5c`),
-			model.NewCardFromString(`6c`),
-		},
+		desc:   `6 choose 2`,
+		hand:   generateHand(6),
+		nCards: 2,
+	}, {
+		desc:   `6 choose 3`,
+		hand:   generateHand(6),
+		nCards: 3,
+	}, {
+		desc:   `6 choose 4`,
+		hand:   generateHand(6),
+		nCards: 4,
+	}, {
+		desc:   `5 choose 2`,
+		hand:   generateHand(5),
+		nCards: 2,
+	}, {
+		desc:   `5 choose 3`,
+		hand:   generateHand(5),
+		nCards: 3,
+	}, {
+		desc:   `5 choose 4`,
+		hand:   generateHand(5),
+		nCards: 4,
 	}}
 	for _, tc := range tests {
 		all := chooseFrom(tc.nCards, tc.hand)
+		expNum, err := nchoosek(len(tc.hand), tc.nCards)
+		require.Nil(t, err)
+		assert.Equal(t, expNum, len(all))
 		for _, h := range all {
+			assert.Equal(t, tc.nCards, len(h))
 			ok := validateHand(tc.hand, h)
 			assert.True(t, ok)
 		}

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -25,13 +25,13 @@ func validateHand(origHand, thisHand []model.Card) bool {
 			return false
 		}
 	}
-	for i := 0; i < len(thisHand)-2; i++ {
-		// check that no duplicates exist in this hand
-		for _, c2 := range thisHand[i+1:] {
-			if thisHand[i] == c2 {
-				return false
-			}
+	cardCache := make(map[model.Card]int)
+	for i, c := range thisHand {
+		_, inMap := cardCache[c]
+		if inMap {
+			return false
 		}
+		cardCache[c] = i
 	}
 	return true
 }

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -25,13 +25,13 @@ func validateHand(origHand, thisHand []model.Card) bool {
 			return false
 		}
 	}
-	cardCache := make(map[model.Card]int)
+	prev := make(map[model.Card]int)
 	for i, c := range thisHand {
-		_, inMap := cardCache[c]
+		_, inMap := prev[c]
 		if inMap {
 			return false
 		}
-		cardCache[c] = i
+		prev[c] = i
 	}
 	return true
 }

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -10,23 +10,23 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
-func validateHand(origHand, thisHand []model.Card) bool {
-	prev := make(map[model.Card]int)
-	for i, c := range thisHand {
-		_, ok := prev[c]
+func validateHand(superset, subset []model.Card) bool {
+	thisHandMap := make(map[model.Card]struct{}, len(subset))
+	for _, c := range subset {
+		_, ok := thisHandMap[c]
 		if ok {
 			return false
 		}
-		prev[c] = i
+		thisHandMap[c] = struct{}{}
 	}
 	ct := 0
-	for _, c := range origHand {
-		_, ok := prev[c]
+	for _, c := range superset {
+		_, ok := thisHandMap[c]
 		if ok {
 			ct++
 		}
 	}
-	return ct == len(thisHand)
+	return ct == len(subset)
 }
 
 func factorial(n int, cache map[int]int) int {
@@ -63,53 +63,58 @@ func TestChooseFrom(t *testing.T) {
 		desc   string
 		hand   []model.Card
 		nCards int
-		expErr bool
+		expErr string
 	}{{
 		desc:   `6 choose 2`,
 		hand:   generateHand(6),
 		nCards: 2,
-		expErr: false,
+		expErr: ``,
 	}, {
 		desc:   `6 choose 3`,
 		hand:   generateHand(6),
 		nCards: 3,
-		expErr: false,
+		expErr: ``,
 	}, {
 		desc:   `6 choose 4`,
 		hand:   generateHand(6),
 		nCards: 4,
-		expErr: false,
+		expErr: ``,
 	}, {
 		desc:   `5 choose 2`,
 		hand:   generateHand(5),
 		nCards: 2,
-		expErr: false,
+		expErr: ``,
 	}, {
 		desc:   `5 choose 3`,
 		hand:   generateHand(5),
 		nCards: 3,
-		expErr: false,
+		expErr: ``,
 	}, {
 		desc:   `5 choose 4`,
 		hand:   generateHand(5),
 		nCards: 4,
-		expErr: false,
+		expErr: ``,
 	}, {
 		desc:   `5 choose 6`,
 		hand:   generateHand(5),
 		nCards: 6,
-		expErr: true,
+		expErr: `developer error: invalid k`,
 	}, {
 		desc:   `choose zero cards`,
 		hand:   generateHand(5),
 		nCards: 0,
-		expErr: true,
+		expErr: `developer error: invalid k`,
+	}, {
+		desc:   `hand too large`,
+		hand:   generateHand(7),
+		nCards: 3,
+		expErr: `too many cards in hand (maximum 6)`,
 	}}
 	fCache := make(map[int]int)
 	for _, tc := range tests {
 		all, err := chooseFrom(tc.nCards, tc.hand)
-		if tc.expErr {
-			assert.NotNil(t, err)
+		if tc.expErr != `` {
+			assert.EqualError(t, err, tc.expErr)
 		} else {
 			assert.Nil(t, err)
 			expNum, err := nchoosek(len(tc.hand), tc.nCards, fCache)

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -1,0 +1,52 @@
+package strategy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/joshprzybyszewski/cribbage/model"
+)
+
+func isIn(c model.Card, h []model.Card) bool {
+	for _, thisCard := range h {
+		if c == thisCard {
+			return true
+		}
+	}
+	return false
+}
+
+func validateHand(origHand, thisHand []model.Card) bool {
+	for _, c := range thisHand {
+		if isIn(c, origHand) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestChooseFrom(t *testing.T) {
+	tests := []struct {
+		desc   string
+		hand   []model.Card
+		nCards int
+	}{{
+		desc: ``,
+		hand: []model.Card{
+			model.NewCardFromString(`ac`),
+			model.NewCardFromString(`2c`),
+			model.NewCardFromString(`3c`),
+			model.NewCardFromString(`4c`),
+			model.NewCardFromString(`5c`),
+			model.NewCardFromString(`6c`),
+		},
+	}}
+	for _, tc := range tests {
+		all := chooseFrom(tc.nCards, tc.hand)
+		for _, h := range all {
+			ok := validateHand(tc.hand, h)
+			assert.True(t, ok)
+		}
+	}
+}

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -36,18 +36,25 @@ func validateHand(origHand, thisHand []model.Card) bool {
 	return true
 }
 
-func factorial(n int) int {
-	if n == 1 {
-		return n
+func factorial(n int, cache map[int]int) int {
+	res, inMap := cache[n]
+	if inMap {
+		return res
 	}
-	return n * factorial(n-1)
+	if n == 1 {
+		res = 1
+	} else {
+		res = n * factorial(n-1, cache)
+	}
+	cache[n] = res
+	return res
 }
 
-func nchoosek(n, k int) (int, error) {
+func nchoosek(n, k int, fCache map[int]int) (int, error) {
 	if k > n {
 		return 0, errors.New(`k must be less than or equal to n`)
 	}
-	return factorial(n) / (factorial(k) * factorial(n-k)), nil
+	return factorial(n, fCache) / (factorial(k, fCache) * factorial(n-k, fCache)), nil
 }
 
 func generateHand(n int) []model.Card {
@@ -105,13 +112,14 @@ func TestChooseFrom(t *testing.T) {
 		nCards: 0,
 		expErr: true,
 	}}
+	fCache := make(map[int]int)
 	for _, tc := range tests {
 		all, err := chooseFrom(tc.nCards, tc.hand)
 		if tc.expErr {
 			assert.NotNil(t, err)
 		} else {
 			assert.Nil(t, err)
-			expNum, err := nchoosek(len(tc.hand), tc.nCards)
+			expNum, err := nchoosek(len(tc.hand), tc.nCards, fCache)
 			require.Nil(t, err)
 			assert.Equal(t, expNum, len(all))
 			for _, h := range all {

--- a/logic/strategy/card_utils_test.go
+++ b/logic/strategy/card_utils_test.go
@@ -63,40 +63,62 @@ func TestChooseFrom(t *testing.T) {
 		desc   string
 		hand   []model.Card
 		nCards int
+		expErr bool
 	}{{
 		desc:   `6 choose 2`,
 		hand:   generateHand(6),
 		nCards: 2,
+		expErr: false,
 	}, {
 		desc:   `6 choose 3`,
 		hand:   generateHand(6),
 		nCards: 3,
+		expErr: false,
 	}, {
 		desc:   `6 choose 4`,
 		hand:   generateHand(6),
 		nCards: 4,
+		expErr: false,
 	}, {
 		desc:   `5 choose 2`,
 		hand:   generateHand(5),
 		nCards: 2,
+		expErr: false,
 	}, {
 		desc:   `5 choose 3`,
 		hand:   generateHand(5),
 		nCards: 3,
+		expErr: false,
 	}, {
 		desc:   `5 choose 4`,
 		hand:   generateHand(5),
 		nCards: 4,
+		expErr: false,
+	}, {
+		desc:   `5 choose 6`,
+		hand:   generateHand(5),
+		nCards: 6,
+		expErr: true,
+	}, {
+		desc:   `choose zero cards`,
+		hand:   generateHand(5),
+		nCards: 0,
+		expErr: true,
 	}}
 	for _, tc := range tests {
-		all := chooseFrom(tc.nCards, tc.hand)
-		expNum, err := nchoosek(len(tc.hand), tc.nCards)
-		require.Nil(t, err)
-		assert.Equal(t, expNum, len(all))
-		for _, h := range all {
-			assert.Equal(t, tc.nCards, len(h))
-			ok := validateHand(tc.hand, h)
-			assert.True(t, ok)
+		all, err := chooseFrom(tc.nCards, tc.hand)
+		if tc.expErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			expNum, err := nchoosek(len(tc.hand), tc.nCards)
+			require.Nil(t, err)
+			assert.Equal(t, expNum, len(all))
+			for _, h := range all {
+				assert.Equal(t, tc.nCards, len(h))
+				ok := validateHand(tc.hand, h)
+				assert.True(t, ok)
+			}
 		}
 	}
 }

--- a/logic/strategy/qa/main.go
+++ b/logic/strategy/qa/main.go
@@ -37,11 +37,19 @@ func main() {
 
 func reportAboutHand(cstrs []string) {
 	fmt.Printf("Calculating for hand: %+v\n", strToCards(cstrs))
-	lowCrib := strategy.GiveCribLowestPotential(0, strToCards(cstrs))
-	fmt.Printf("GiveCribLowestPotential: %+v\n", lowCrib)
+	lowCrib, err := strategy.GiveCribLowestPotential(0, strToCards(cstrs))
+	if err != nil {
+		fmt.Printf("GiveCribLowestPotential: Error! %v\n", err)
+	} else {
+		fmt.Printf("GiveCribLowestPotential: %+v\n", lowCrib)
+	}
 
-	highCrib := strategy.GiveCribHighestPotential(0, strToCards(cstrs))
-	fmt.Printf("GiveCribHighestPotential: %+v\n", highCrib)
+	highCrib, err := strategy.GiveCribHighestPotential(0, strToCards(cstrs))
+	if err != nil {
+		fmt.Printf("GiveCribHighestPotential: Error! %v\n", err)
+	} else {
+		fmt.Printf("GiveCribHighestPotential: %+v\n", highCrib)
+	}
 }
 
 func strToCards(s []string) []model.Card {


### PR DESCRIPTION
Addresses #22 

Fix the util function `chooseFrom`, which previously returned combinations of hands containing duplicate cards. This also reduced the cyclomatic complexity enough to not have to ignore the linter 😄