### PR TITLE
Auth with JSON web tokens

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Credentials are used to authorize a user
+type Credentials struct {
+	Username     string
+	PasswordHash string
+}
+
+// NewCredentials takes a username and plaintext password, hashes the password, and returns Credentials
+func NewCredentials(username, password string) (Credentials, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), 10)
+	if err != nil {
+		return Credentials{}, err
+	}
+	return Credentials{
+		Username:     username,
+		PasswordHash: string(hash),
+	}, nil
+}
+
+// ValidateCredentials compares a username and plaintext password to a Credentials object
+func ValidateCredentials(username, password string, creds Credentials) (bool, error) {
+	if username != creds.Username {
+		return false, nil
+	}
+	err := bcrypt.CompareHashAndPassword([]byte(creds.PasswordHash), []byte(password))
+	if err != nil {
+		if err == bcrypt.ErrMismatchedHashAndPassword {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,8 +6,8 @@ import (
 
 // Credentials are used to authorize a user
 type Credentials struct {
-	Username     string
-	PasswordHash string
+	Username     string `json:"username"`
+	PasswordHash string `json:"-"`
 }
 
 // NewCredentials takes a username and plaintext password, hashes the password, and returns Credentials

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -1,13 +1,14 @@
 package auth
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
 )
 
 type claims struct {
-	username string
+	Username string `json:"username"`
 	jwt.StandardClaims
 }
 
@@ -29,9 +30,10 @@ func NewJWTService(key string, validFor time.Duration) JWTService {
 	}
 }
 
+// CreateToken creates and signs a JSON web token
 func (js JWTService) CreateToken(username string) (Token, error) {
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, &claims{
-		username: username,
+		Username: username,
 		StandardClaims: jwt.StandardClaims{
 			ExpiresAt: time.Now().Add(js.validFor).Unix(),
 		},
@@ -41,4 +43,25 @@ func (js JWTService) CreateToken(username string) (Token, error) {
 		return Token{}, err
 	}
 	return Token{Token: tokStr}, nil
+}
+
+// ValidateAndParseToken makes sure the token is valid given the token key, then returns the username contained within
+// the token
+func (js JWTService) ValidateAndParseToken(tokenStr string) (bool, string, error) {
+	if tokenStr == `` {
+		return false, ``, nil
+	}
+	tok, err := jwt.ParseWithClaims(tokenStr, &claims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf(`Unexpected signing method: %v`, token.Header[`alg`])
+		}
+		return js.jwtKey, nil
+	})
+	if err != nil {
+		return false, ``, err
+	}
+	if cl, ok := tok.Claims.(*claims); ok && tok.Valid {
+		return true, cl.Username, nil
+	}
+	return false, ``, nil
 }

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+type claims struct {
+	username string
+	jwt.StandardClaims
+}
+
+type JWTService struct {
+	jwtKey   string
+	validFor time.Duration
+}
+
+func NewJWTService(key string, validFor time.Duration) JWTService {
+	return JWTService{
+		jwtKey:   key,
+		validFor: validFor,
+	}
+}
+
+func (js JWTService) CreateToken(username string) (string, error) {
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, &claims{
+		username: username,
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(js.validFor).Unix(),
+		},
+	})
+	tokStr, err := tok.SignedString(js.jwtKey)
+	if err != nil {
+		return ``, err
+	}
+	return tokStr, nil
+}

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -11,6 +11,12 @@ type claims struct {
 	jwt.StandardClaims
 }
 
+// Token is just used to serialize a token string to JSON
+type Token struct {
+	Token string `json:"token"`
+}
+
+// JWTService is used to generate tokens
 type JWTService struct {
 	jwtKey   string
 	validFor time.Duration
@@ -23,7 +29,7 @@ func NewJWTService(key string, validFor time.Duration) JWTService {
 	}
 }
 
-func (js JWTService) CreateToken(username string) (string, error) {
+func (js JWTService) CreateToken(username string) (Token, error) {
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, &claims{
 		username: username,
 		StandardClaims: jwt.StandardClaims{
@@ -32,7 +38,7 @@ func (js JWTService) CreateToken(username string) (string, error) {
 	})
 	tokStr, err := tok.SignedString(js.jwtKey)
 	if err != nil {
-		return ``, err
+		return Token{}, err
 	}
-	return tokStr, nil
+	return Token{Token: tokStr}, nil
 }

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -45,9 +45,12 @@ func (js JWTService) CreateCookie(username string) (http.Cookie, error) {
 		return http.Cookie{}, err
 	}
 	return http.Cookie{
-		Name:    `token`,
-		Value:   tokStr,
-		Expires: expTime,
+		Name:     `token`,
+		Value:    tokStr,
+		Expires:  expTime,
+		MaxAge:   int(js.validFor.Seconds()),
+		Secure:   false,
+		HttpOnly: true,
 	}, nil
 }
 

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -18,13 +18,13 @@ type Token struct {
 
 // JWTService is used to generate tokens
 type JWTService struct {
-	jwtKey   string
+	jwtKey   []byte
 	validFor time.Duration
 }
 
 func NewJWTService(key string, validFor time.Duration) JWTService {
 	return JWTService{
-		jwtKey:   key,
+		jwtKey:   []byte(key),
 		validFor: validFor,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.0.4
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-gonic/gin v1.4.0
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
@@ -12,5 +13,6 @@ require (
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
 	go.mongodb.org/mongo-driver v1.1.3
+	golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3 h1:t8FVkw33L+wilf2QiWkw0UV77qRpcH/JHPKGpKa2E8g=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0 h1:3tMoCCfM7ppqsR0ptz/wi1impNpT7/9wQtMZ8lr1mCQ=

--- a/model/model.go
+++ b/model/model.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/joshprzybyszewski/cribbage/auth"
+
 type Suit int
 
 const (
@@ -54,6 +56,7 @@ func (c PlayerColor) String() string {
 }
 
 type Player struct {
+	auth.Credentials
 	ID    PlayerID               `protobuf:"varint,1,req,name=id,proto3" json:"id" bson:"id"`                           //nolint:lll
 	Name  string                 `protobuf:"string,2,req,name=name,proto3" json:"n" bson:"n"`                           //nolint:lll
 	Games map[GameID]PlayerColor `protobuf:"map<varint, varint>,3,opt,name=games,proto3" json:"gs,omitempty" bson:"gs"` //nolint:lll

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/joshprzybyszewski/cribbage/auth"
+)
+
+func Auth() gin.HandlerFunc {
+	jwtSvc := auth.NewJWTService(`somethingSecret`, time.Second)
+	return func(c *gin.Context) {
+		tok := c.GetHeader(`x-auth-token`)
+		isValid, user, err := jwtSvc.ValidateAndParseToken(tok)
+		if err != nil {
+			c.String(http.StatusInternalServerError, `Error: %s`, err)
+			return
+		}
+		if !isValid {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		fmt.Println(`setting user to: ` + user)
+		c.Set(`user`, user)
+	}
+}

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -22,7 +21,6 @@ func Auth() gin.HandlerFunc {
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}
-		fmt.Println(`setting user to: ` + user)
 		c.Set(`user`, user)
 	}
 }

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -11,14 +11,21 @@ import (
 func Auth() gin.HandlerFunc {
 	jwtSvc := auth.NewJWTService(`somethingSecret`, time.Second)
 	return func(c *gin.Context) {
-		tok := c.GetHeader(`x-auth-token`)
+		tok, err := c.Cookie(`token`)
+		if err != nil {
+			c.String(http.StatusUnauthorized, `Unauthorized!`)
+			c.Abort()
+			return
+		}
 		isValid, user, err := jwtSvc.ValidateAndParseToken(tok)
 		if err != nil {
 			c.String(http.StatusInternalServerError, `Error: %s`, err)
+			c.Abort()
 			return
 		}
 		if !isValid {
-			c.AbortWithStatus(http.StatusUnauthorized)
+			c.String(http.StatusUnauthorized, `Unauthorized!`)
+			c.Abort()
 			return
 		}
 		c.Set(`user`, user)

--- a/server/server.go
+++ b/server/server.go
@@ -92,12 +92,12 @@ func (cs *cribbageServer) ginPostRegister(c *gin.Context) {
 	}
 	// TODO make the key more secret (environment var), change expiration duration to much shorter
 	jwtSvc := auth.NewJWTService(`somethingSecret`, time.Minute*180)
-	tok, err := jwtSvc.CreateToken(creds.Username)
+	cookie, err := jwtSvc.CreateCookie(creds.Username)
 	if err != nil {
 		c.String(http.StatusInternalServerError, `Error: %s`, err)
 		return
 	}
-	c.JSON(http.StatusOK, tok)
+	c.SetCookie(cookie.Name, cookie.Value, cookie.MaxAge, cookie.Path, cookie.Domain, cookie.Secure, cookie.HttpOnly)
 }
 
 func (cs *cribbageServer) ginPostLogin(c *gin.Context) {
@@ -124,12 +124,12 @@ func (cs *cribbageServer) ginPostLogin(c *gin.Context) {
 		return
 	}
 	jwtSvc := auth.NewJWTService(`somethingSecret`, time.Minute*180)
-	tok, err := jwtSvc.CreateToken(player.Credentials.Username)
+	cookie, err := jwtSvc.CreateCookie(player.Credentials.Username)
 	if err != nil {
 		c.String(http.StatusInternalServerError, `Error: %s`, err)
 		return
 	}
-	c.JSON(http.StatusOK, tok)
+	c.SetCookie(cookie.Name, cookie.Value, cookie.MaxAge, cookie.Path, cookie.Domain, cookie.Secure, cookie.HttpOnly)
 }
 
 func decodeUserAndPass(c *gin.Context) (string, string, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -9,15 +9,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/joshprzybyszewski/cribbage/server/middleware"
-
-	"github.com/joshprzybyszewski/cribbage/auth"
-
 	"github.com/gin-gonic/gin"
 
+	"github.com/joshprzybyszewski/cribbage/auth"
 	"github.com/joshprzybyszewski/cribbage/jsonutils"
 	"github.com/joshprzybyszewski/cribbage/model"
 	"github.com/joshprzybyszewski/cribbage/server/interaction"
+	"github.com/joshprzybyszewski/cribbage/server/middleware"
 	"github.com/joshprzybyszewski/cribbage/server/persistence"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/joshprzybyszewski/cribbage/server/middleware"
+
 	"github.com/joshprzybyszewski/cribbage/auth"
 
 	"github.com/gin-gonic/gin"
@@ -37,6 +39,14 @@ func (cs *cribbageServer) Serve() {
 	{
 		authGroup.POST(`/login`, cs.ginPostLogin)
 		authGroup.POST(`/register`, cs.ginPostRegister)
+	}
+	// Group: private
+	private := router.Group(`/private`)
+	private.Use(middleware.Auth())
+	{
+		private.GET(`/`, func(c *gin.Context) {
+			c.String(http.StatusOK, `SUPER SECRET, user: %s`, c.GetString(`user`))
+		})
 	}
 
 	// Simple group: create

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -110,7 +109,6 @@ func (cs *cribbageServer) ginPostLogin(c *gin.Context) {
 	player, err := getPlayer(model.PlayerID(u))
 	if err != nil {
 		if err == persistence.ErrPlayerNotFound {
-			fmt.Println(`player not found`)
 			c.String(http.StatusUnauthorized, `Invalid credentials`)
 			return
 		}
@@ -122,7 +120,6 @@ func (cs *cribbageServer) ginPostLogin(c *gin.Context) {
 		return
 	}
 	if !isAuthorized {
-		fmt.Println(`passwords don't match`)
 		c.String(http.StatusUnauthorized, `Invalid credentials`)
 		return
 	}


### PR DESCRIPTION
I took a mulligan on auth - I think JWT is going to be easier than using OAuth2 for our purposes. Addresses #36 

- Add the `auth` package to take care of generating and validating JWTs as well as hashing and comparing passwords
- Add `/auth/register` and `/auth/login` routes. Both new routes do their thing to add or validate the user against the DB and then issue a token back to the client. The client will then include the token in its header whenever it hits the API
- Add auth middleware to protect private routes (there's just a test one for now). The middleware validates the token in a request's header and, if valid, adds the username to the request before moving on