### PR TITLE
Fix #39

### DIFF
--- a/localclient/terminal_player.go
+++ b/localclient/terminal_player.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/joshprzybyszewski/cribbage/model"
+	"github.com/joshprzybyszewski/cribbage/network"
 )
 
 const (
@@ -276,15 +277,15 @@ func (tc *terminalClient) makeRequest(method, apiURL string, data io.Reader) ([]
 	}
 	defer response.Body.Close()
 
-	bytes, err := ioutil.ReadAll(response.Body)
+	resBytes, err := ioutil.ReadAll(response.Body)
 
 	if response.StatusCode != http.StatusOK {
 		// Keeping this here for debugging
-		fmt.Printf("full response: %+v\n%s\n%s\n", response, response.Body, string(bytes))
+		fmt.Printf("full response: %+v\n%s\n%s\n", response, response.Body, string(resBytes))
 
 		contentType := response.Header.Get("Content-Type")
 		if strings.Contains(contentType, `text/plain`) {
-			return nil, fmt.Errorf("bad response: \"%s\"", string(bytes))
+			return nil, fmt.Errorf("bad response: \"%s\"", string(resBytes))
 		}
 
 		return nil, fmt.Errorf("bad response from server")
@@ -297,11 +298,7 @@ func (tc *terminalClient) makeRequest(method, apiURL string, data io.Reader) ([]
 
 func (tc *terminalClient) createPlayer() error {
 	username, name := tc.getName()
-	// TODO maybe we should define this type in the server -- but do we want to import server here?
-	var reqData = struct {
-		Username    string `json:"username"`
-		DisplayName string `json:"displayName"`
-	}{username, name}
+	var reqData = network.CreatePlayerModel{Username: username, DisplayName: name}
 	b, err := json.Marshal(reqData)
 	if err != nil {
 		return err

--- a/localclient/terminal_player.go
+++ b/localclient/terminal_player.go
@@ -2,6 +2,7 @@ package localclient
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -296,8 +297,16 @@ func (tc *terminalClient) makeRequest(method, apiURL string, data io.Reader) ([]
 
 func (tc *terminalClient) createPlayer() error {
 	username, name := tc.getName()
-
-	respBytes, err := tc.makeRequest(`POST`, `/create/player/`+username+`/`+name, nil)
+	var reqData = struct {
+		Username    string `json:"username"`
+		DisplayName string `json:"displayName"`
+	}{username, name}
+	b, err := json.Marshal(reqData)
+	if err != nil {
+		return err
+	}
+	// TODO do we need makeRequest to set Content-Type to application/json in the header?
+	respBytes, err := tc.makeRequest(`POST`, `/create/player`, bytes.NewReader(b))
 	if err != nil {
 		return err
 	}

--- a/localclient/terminal_player.go
+++ b/localclient/terminal_player.go
@@ -293,7 +293,7 @@ func (tc *terminalClient) makeRequest(method, apiURL string, data io.Reader) ([]
 		return nil, err
 	}
 
-	return bytes, nil
+	return resBytes, nil
 }
 
 func (tc *terminalClient) createPlayer() error {

--- a/localclient/terminal_player.go
+++ b/localclient/terminal_player.go
@@ -297,6 +297,7 @@ func (tc *terminalClient) makeRequest(method, apiURL string, data io.Reader) ([]
 
 func (tc *terminalClient) createPlayer() error {
 	username, name := tc.getName()
+	// TODO maybe we should define this type in the server -- but do we want to import server here?
 	var reqData = struct {
 		Username    string `json:"username"`
 		DisplayName string `json:"displayName"`

--- a/network/model.go
+++ b/network/model.go
@@ -1,6 +1,6 @@
-package server
+package network
 
-type CreatePlayerData struct {
+type CreatePlayerModel struct {
 	Username    string `json:"username"`
 	DisplayName string `json:"displayName"`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -21,19 +21,19 @@ func (cs *cribbageServer) Serve() {
 	router := gin.Default()
 
 	// Simple group: create
-	create := router.Group("/create")
+	create := router.Group(`/create`)
 	{
-		create.POST("/game/:player1/:player2", cs.ginPostCreateGame)
-		create.POST("/game/:player1/:player2/:player3", cs.ginPostCreateGame)
-		create.POST("/game/:player1/:player2/:player3/:player4", cs.ginPostCreateGame)
-		create.POST("/player", cs.ginPostCreatePlayer)
-		create.POST("/interaction/:playerId/:mode/:info", cs.ginPostCreateInteraction)
+		create.POST(`/game/:player1/:player2`, cs.ginPostCreateGame)
+		create.POST(`/game/:player1/:player2/:player3`, cs.ginPostCreateGame)
+		create.POST(`/game/:player1/:player2/:player3/:player4`, cs.ginPostCreateGame)
+		create.POST(`/player`, cs.ginPostCreatePlayer)
+		create.POST(`/interaction/:playerId/:mode/:info`, cs.ginPostCreateInteraction)
 	}
 
-	router.GET("/game/:gameID", cs.ginGetGame)
-	router.GET("/player/:username", cs.ginGetPlayer)
+	router.GET(`/game/:gameID`, cs.ginGetGame)
+	router.GET(`/player/:username`, cs.ginGetPlayer)
 
-	router.POST("/action/:gameID", cs.ginPostAction)
+	router.POST(`/action/:gameID`, cs.ginPostAction)
 
 	err := router.Run() // listen and serve on 0.0.0.0:8080
 	if err != nil {
@@ -46,14 +46,14 @@ func (cs *cribbageServer) ginPostCreateGame(c *gin.Context) {
 
 	pID := getPlayerID(c, `player1`)
 	if pID == model.InvalidPlayerID {
-		c.String(http.StatusBadRequest, "Needs player1")
+		c.String(http.StatusBadRequest, `Needs player1`)
 		return
 	}
 	pIDs = append(pIDs, pID)
 
 	pID = getPlayerID(c, `player2`)
 	if pID == model.InvalidPlayerID {
-		c.String(http.StatusBadRequest, "Needs player2")
+		c.String(http.StatusBadRequest, `Needs player2`)
 		return
 	}
 	pIDs = append(pIDs, pID)
@@ -69,13 +69,13 @@ func (cs *cribbageServer) ginPostCreateGame(c *gin.Context) {
 	}
 
 	if len(pIDs) < model.MinPlayerGame || len(pIDs) > model.MaxPlayerGame {
-		c.String(http.StatusBadRequest, "Invalid num players: %d", len(pIDs))
+		c.String(http.StatusBadRequest, `Invalid num players: %d`, len(pIDs))
 		return
 	}
 
 	g, err := createGameFromIDs(pIDs)
 	if err != nil {
-		c.String(http.StatusInternalServerError, "createGame error: %s", err)
+		c.String(http.StatusInternalServerError, `createGame error: %s`, err)
 		return
 	}
 
@@ -106,11 +106,11 @@ func (cs *cribbageServer) ginPostCreatePlayer(c *gin.Context) {
 	if err != nil {
 		switch err {
 		case persistence.ErrPlayerAlreadyExists:
-			c.String(http.StatusBadRequest, "Username already exists")
+			c.String(http.StatusBadRequest, `Username already exists`)
 		case errInvalidUsername:
-			c.String(http.StatusBadRequest, "Username must be alphanumeric")
+			c.String(http.StatusBadRequest, `Username must be alphanumeric`)
 		default:
-			c.String(http.StatusInternalServerError, "Error: %s", err)
+			c.String(http.StatusInternalServerError, `Error: %s`, err)
 		}
 		return
 	}
@@ -120,7 +120,7 @@ func (cs *cribbageServer) ginPostCreatePlayer(c *gin.Context) {
 func (cs *cribbageServer) ginPostCreateInteraction(c *gin.Context) {
 	pID := getPlayerID(c, `playerId`)
 	if pID == model.InvalidPlayerID {
-		c.String(http.StatusBadRequest, "Needs playerId")
+		c.String(http.StatusBadRequest, `Needs playerId`)
 		return
 	}
 
@@ -129,7 +129,7 @@ func (cs *cribbageServer) ginPostCreateInteraction(c *gin.Context) {
 	case `localhost`:
 		mode = interaction.Localhost
 	default:
-		c.String(http.StatusBadRequest, "unsupported interaction mode")
+		c.String(http.StatusBadRequest, `unsupported interaction mode`)
 		return
 	}
 
@@ -139,21 +139,21 @@ func (cs *cribbageServer) ginPostCreateInteraction(c *gin.Context) {
 		Info: info,
 	})
 	if err != nil {
-		c.String(http.StatusInternalServerError, "Error: %s", err)
+		c.String(http.StatusInternalServerError, `Error: %s`, err)
 		return
 	}
-	c.String(http.StatusOK, "Updated player interaction")
+	c.String(http.StatusOK, `Updated player interaction`)
 }
 
 func (cs *cribbageServer) ginGetGame(c *gin.Context) {
 	gID, err := getGameIDFromContext(c)
 	if err != nil {
-		c.String(http.StatusBadRequest, "Invalid GameID: %v", err)
+		c.String(http.StatusBadRequest, `Invalid GameID: %v`, err)
 		return
 	}
 	g, err := getGame(gID)
 	if err != nil {
-		c.String(http.StatusInternalServerError, "Error: %s", err)
+		c.String(http.StatusInternalServerError, `Error: %s`, err)
 		return
 	}
 	// TODO investigate what it'll take to protobuf-ify our models
@@ -161,7 +161,7 @@ func (cs *cribbageServer) ginGetGame(c *gin.Context) {
 }
 
 func getGameIDFromContext(c *gin.Context) (model.GameID, error) {
-	gIDStr := c.Param("gameID")
+	gIDStr := c.Param(`gameID`)
 	n, err := strconv.Atoi(gIDStr)
 	if err != nil {
 		return model.InvalidGameID, err
@@ -170,10 +170,10 @@ func getGameIDFromContext(c *gin.Context) (model.GameID, error) {
 }
 
 func (cs *cribbageServer) ginGetPlayer(c *gin.Context) {
-	pID := model.PlayerID(c.Param("username"))
+	pID := model.PlayerID(c.Param(`username`))
 	p, err := getPlayer(pID)
 	if err != nil {
-		c.String(http.StatusInternalServerError, "Error: %s", err)
+		c.String(http.StatusInternalServerError, `Error: %s`, err)
 		return
 	}
 	// TODO investigate what it'll take to protobuf-ify our models
@@ -183,17 +183,17 @@ func (cs *cribbageServer) ginGetPlayer(c *gin.Context) {
 func (cs *cribbageServer) ginPostAction(c *gin.Context) {
 	action, err := unmarshalPlayerAction(c.Request)
 	if err != nil {
-		c.String(http.StatusBadRequest, "Error: %s", err)
+		c.String(http.StatusBadRequest, `Error: %s`, err)
 		return
 	}
 
 	err = handlePlayerAction(action)
 	if err != nil {
-		c.String(http.StatusBadRequest, "Error: %s", err)
+		c.String(http.StatusBadRequest, `Error: %s`, err)
 		return
 	}
 
-	c.String(http.StatusOK, "action handled")
+	c.String(http.StatusOK, `action handled`)
 }
 
 func unmarshalPlayerAction(req *http.Request) (model.PlayerAction, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -99,9 +99,16 @@ func getPlayerID(c *gin.Context, playerParam string) model.PlayerID {
 }
 
 func (cs *cribbageServer) ginPostCreatePlayer(c *gin.Context) {
-	username := c.Param("username")
-	name := c.Param("name")
-	player, err := createPlayerFromNames(username, name)
+	var reqData struct {
+		Username    string `json:"username"`
+		DisplayName string `json:"displayName"`
+	}
+	err := c.ShouldBindJSON(&reqData)
+	if err != nil {
+		c.String(http.StatusInternalServerError, `Error: %s`, err)
+		return
+	}
+	player, err := createPlayerFromNames(reqData.Username, reqData.DisplayName)
 	if err != nil {
 		switch err {
 		case persistence.ErrPlayerAlreadyExists:

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ func (cs *cribbageServer) Serve() {
 		create.POST("/game/:player1/:player2", cs.ginPostCreateGame)
 		create.POST("/game/:player1/:player2/:player3", cs.ginPostCreateGame)
 		create.POST("/game/:player1/:player2/:player3/:player4", cs.ginPostCreateGame)
-		create.POST("/player/:username/:name", cs.ginPostCreatePlayer)
+		create.POST("/player", cs.ginPostCreatePlayer)
 		create.POST("/interaction/:playerId/:mode/:info", cs.ginPostCreateInteraction)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/joshprzybyszewski/cribbage/jsonutils"
 	"github.com/joshprzybyszewski/cribbage/model"
+	"github.com/joshprzybyszewski/cribbage/network"
 	"github.com/joshprzybyszewski/cribbage/server/interaction"
 	"github.com/joshprzybyszewski/cribbage/server/persistence"
 )
@@ -103,7 +104,7 @@ func getPlayerID(c *gin.Context, playerParam string) model.PlayerID {
 }
 
 func (cs *cribbageServer) ginPostCreatePlayer(c *gin.Context) {
-	var reqData CreatePlayerData
+	var reqData network.CreatePlayerModel
 	err := c.ShouldBindJSON(&reqData)
 	if err != nil {
 		c.String(http.StatusInternalServerError, `Error: %s`, err)

--- a/server/server.go
+++ b/server/server.go
@@ -20,12 +20,6 @@ type cribbageServer struct {
 func (cs *cribbageServer) Serve() {
 	router := gin.Default()
 
-	router.GET("/ping", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{
-			"message": "pong",
-		})
-	})
-
 	// Simple group: create
 	create := router.Group("/create")
 	{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/joshprzybyszewski/cribbage/model"
+	"github.com/joshprzybyszewski/cribbage/network"
 )
 
 func performRequest(r http.Handler, method, path string, body io.Reader) (*httptest.ResponseRecorder, error) {
@@ -37,7 +38,7 @@ func readBody(t *testing.T, r io.Reader, v interface{}) {
 func TestGinPostCreatePlayer(t *testing.T) {
 	testCases := []struct {
 		msg     string
-		data    CreatePlayerData
+		data    network.CreatePlayerModel
 		expRes  model.Player
 		expCode int
 	}{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/joshprzybyszewski/cribbage/model"
+)
+
+func performRequest(r http.Handler, method, path string, body io.Reader) (*httptest.ResponseRecorder, error) {
+	req, err := http.NewRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w, nil
+}
+
+func readBody(t *testing.T, r io.Reader, v interface{}) {
+	bs, err := ioutil.ReadAll(r)
+	fmt.Println(string(bs))
+	require.NoError(t, err)
+	err = json.Unmarshal(bs, v)
+	require.NoError(t, err)
+}
+
+func TestGinPostCreatePlayer(t *testing.T) {
+	testCases := []struct {
+		msg     string
+		data    CreatePlayerData
+		expRes  model.Player
+		expCode int
+	}{
+		/*
+			TODO add test cases once the server is more testable. We need to rewrite it to inject persistence in so we can mock it here
+			(or at least set it to memory instead of mongo by default)
+		*/
+	}
+	cs := &cribbageServer{}
+	router := cs.NewRouter()
+	for _, tc := range testCases {
+		reqBytes, err := json.Marshal(tc.data)
+		require.NoError(t, err)
+		body := bytes.NewReader(reqBytes)
+		w, err := performRequest(router, `POST`, `/create/player`, body)
+		require.NoError(t, err)
+		assert.Equal(t, tc.expCode, w.Code)
+		if tc.expCode == http.StatusOK {
+			var player model.Player
+			readBody(t, w.Body, &player)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expRes, player)
+		}
+	}
+}

--- a/server/types.go
+++ b/server/types.go
@@ -1,0 +1,6 @@
+package server
+
+type CreatePlayerData struct {
+	Username    string `json:"username"`
+	DisplayName string `json:"displayName"`
+}


### PR DESCRIPTION
Addresses #39 

- Send the player details to the server as JSON in the body instead of as URL params
- Create a starting framework for testing routes. As mentioned in the comments, we need to inject the persistence into the server or have _some_ way of setting or mocking it for testing. My feeling is that that should be in a different PR and will not be a small job...