### PR TITLE
Fix up codecov for golang

### DIFF
--- a/.github/workflows/go_tests.yaml
+++ b/.github/workflows/go_tests.yaml
@@ -30,8 +30,10 @@ jobs:
       with:
         mongodb-version: 4.2
         mongodb-replica-set: testReplSet
+    - name: get go-acc
+      run: go get -u github.com/ory/go-acc
     - name: Run Golang Tests
-      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic -coverpkg $(go list github.com/joshprzybyszewski/cribbage) github.com/joshprzybyszewski/cribbage/...  # Run all the tests with the race detector enabled
+      run: go-acc -o my-coverfile.txt ./...
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/go_tests.yaml
+++ b/.github/workflows/go_tests.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: get go-acc
       run: go get -u github.com/ory/go-acc
     - name: Run Golang Tests
-      run: go-acc -o my-coverfile.txt ./...
+      run: go-acc -o coverage.txt ./...
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/go_tests.yaml
+++ b/.github/workflows/go_tests.yaml
@@ -31,7 +31,7 @@ jobs:
         mongodb-version: 4.2
         mongodb-replica-set: testReplSet
     - name: Run Golang Tests
-      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic -coverpkg $(go list github.com/joshprzybyszewski/cribbage) ./...  # Run all the tests with the race detector enabled
+      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic -coverpkg $(go list github.com/joshprzybyszewski/cribbage) github.com/joshprzybyszewski/cribbage/...  # Run all the tests with the race detector enabled
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/go_tests.yaml
+++ b/.github/workflows/go_tests.yaml
@@ -31,7 +31,7 @@ jobs:
         mongodb-version: 4.2
         mongodb-replica-set: testReplSet
     - name: Run Golang Tests
-      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...  # Run all the tests with the race detector enabled
+      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic -coverpkg $(go list github.com/joshprzybyszewski/cribbage) ./...  # Run all the tests with the race detector enabled
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:


### PR DESCRIPTION
## What broke / What you're adding
Codecov says coverage is lower than it is because it doesn't look at cross-package coverage.

## How you did it
I followed [this article](http://ory.sh/golang-go-code-coverage-accurate)'s example of how to get accurate codecov

## How to test it and how to try to break it
See codecov percentage (hopefully) go up. Particularly, see that the mysql package is shown as tested and that the mongodb package is shown as tested.