### PR TITLE
Add timestamps to player's actions and use case-sensitive collation

### DIFF
--- a/.github/workflows/go_tests.yaml
+++ b/.github/workflows/go_tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0.19
         env:
           MYSQL_ROOT_PASSWORD: githubactionpassword
           MYSQL_DATABASE: testing_cribbage
@@ -19,29 +19,29 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.14.x
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Start MongoDB
-      uses: supercharge/mongodb-github-action@1.3.0
-      with:
-        mongodb-version: 4.2
-        mongodb-replica-set: testReplSet
-    - name: get go-acc
-      run: go get -u github.com/ory/go-acc
-    - name: Run Golang Tests
-      run: go-acc -o coverage.txt ./...
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.txt
-        # flags: unittests
-        # env_vars: OS,PYTHON
-        # name: codecov-umbrella
-        fail_ci_if_error: true
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.x
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
+        with:
+          mongodb-version: 4.2
+          mongodb-replica-set: testReplSet
+      - name: get go-acc
+        run: go get -u github.com/ory/go-acc
+      - name: Run Golang Tests
+        run: go-acc -o coverage.txt ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.txt
+          # flags: unittests
+          # env_vars: OS,PYTHON
+          # name: codecov-umbrella
+          fail_ci_if_error: true
   dockerimage:
     needs: test
     runs-on: ubuntu-latest

--- a/inis/default/cribbage.ini
+++ b/inis/default/cribbage.ini
@@ -2,3 +2,4 @@ restPort=8080
 dsn_host=127.0.0.1
 dsn_user=root
 dsn_password=
+dsn_params=parseTime=true&timeout=90s&writeTimeout=90s&readTimeout=90s&tls=skip-verify&maxAllowedPacket=1000000000&rejectReadOnly=true

--- a/jsonutils/gameUnmarshaller.go
+++ b/jsonutils/gameUnmarshaller.go
@@ -17,7 +17,8 @@ func UnmarshalGame(b []byte) (model.Game, error) {
 		return model.Game{}, err
 	}
 
-	for i, a := range game.Actions {
+	for i := range game.Actions {
+		a := game.Actions[i]
 		b, err := json.Marshal(a)
 		if err != nil {
 			return model.Game{}, err

--- a/model/model.go
+++ b/model/model.go
@@ -148,10 +148,10 @@ type CribBlocker struct {
 }
 
 type PlayerAction struct {
-	GameID    GameID      `json:"gID" bson:"gID"`            
-	ID        PlayerID    `json:"pID" bson:"pID"`            
-	Overcomes Blocker     `json:"o" bson:"o"`                
-	Action    interface{} `json:"a" bson:"a"`                
+	GameID    GameID      `json:"gID" bson:"gID"`
+	ID        PlayerID    `json:"pID" bson:"pID"`
+	Overcomes Blocker     `json:"o" bson:"o"`
+	Action    interface{} `json:"a" bson:"a"`
 	TimeStamp time.Time   `json:"timestamp" bson:"timestamp"`
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -1,5 +1,7 @@
 package model
 
+import "time"
+
 type Suit int
 
 const (
@@ -146,10 +148,11 @@ type CribBlocker struct {
 }
 
 type PlayerAction struct {
-	GameID    GameID      `protobuf:"varint,1,req,name=gameID,proto3" json:"gID" bson:"gID"` //nolint:lll
-	ID        PlayerID    `protobuf:"varint,2,req,name=id,proto3" json:"pID" bson:"pID"`     //nolint:lll
-	Overcomes Blocker     `protobuf:"varint,3,req,name=overcomes,proto3" json:"o" bson:"o"`  //nolint:lll
-	Action    interface{} `protobuf:"-" json:"a" bson:"a"`                                   //nolint:lll
+	GameID    GameID      `json:"gID" bson:"gID"`            
+	ID        PlayerID    `json:"pID" bson:"pID"`            
+	Overcomes Blocker     `json:"o" bson:"o"`                
+	Action    interface{} `json:"a" bson:"a"`                
+	TimeStamp time.Time   `json:"timestamp" bson:"timestamp"`
 }
 
 type DealAction struct {

--- a/network/player.go
+++ b/network/player.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"sort"
 	"time"
 
 	"github.com/joshprzybyszewski/cribbage/model"
@@ -83,6 +84,7 @@ func convertToParticipatingGames(
 			res = append(res, getActiveGame(mg))
 		}
 	}
+	sort.Slice(res, func(i, j int) bool { return !res[i].LastMove.Before(res[j].LastMove) })
 	return res
 }
 

--- a/network/player.go
+++ b/network/player.go
@@ -90,6 +90,10 @@ func getActiveGame(mg model.Game) ActiveGame {
 	ag := ActiveGame{
 		GameID: mg.ID,
 	}
+	if len(mg.Actions) > 0 {
+		ag.Created = mg.Actions[0].TimeStamp
+		ag.LastMove = mg.Actions[len(mg.Actions)-1].TimeStamp
+	}
 	ag.Players = make([]ActiveGamePlayer, len(mg.Players))
 	for i, p := range mg.Players {
 		pID := p.ID

--- a/network/player_test.go
+++ b/network/player_test.go
@@ -81,7 +81,7 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 		inputGames map[model.GameID]model.Game
 		expResp    GetActiveGamesForPlayerResponse
 	}{{
-		desc: ``,
+		desc: `knows how to sort based on timestamp`,
 		player: model.Player{
 			ID:   aliceID,
 			Name: `alice`,
@@ -190,7 +190,7 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 			}},
 		},
 	}, {
-		desc: `games where alice isn't playing`,
+		desc: `knows how to filter games where alice isn't playing`,
 		player: model.Player{
 			ID:   aliceID,
 			Name: `alice`,

--- a/network/player_test.go
+++ b/network/player_test.go
@@ -72,6 +72,9 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 	chelseaID := model.PlayerID(`chelsea`)
 	daveID := model.PlayerID(`dave`)
 
+	t2 := time.Now()
+	t1 := t2.Add(-time.Minute)
+
 	tests := []struct {
 		desc       string
 		player     model.Player
@@ -116,6 +119,9 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					aliceID:   model.Red,
 					chelseaID: model.Blue,
 				},
+				Actions: []model.PlayerAction{{
+					TimeStamp: t1,
+				}},
 			},
 			789: {
 				ID: 789,
@@ -130,6 +136,11 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					aliceID: model.Red,
 					daveID:  model.Blue,
 				},
+				Actions: []model.PlayerAction{{
+					TimeStamp: t1,
+				}, {
+					TimeStamp: t2,
+				}},
 			},
 		},
 		expResp: GetActiveGamesForPlayerResponse{
@@ -138,18 +149,18 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 				Name: `alice`,
 			},
 			ActiveGames: []ActiveGame{{
-				GameID: 123,
+				GameID: 789,
 				Players: []ActiveGamePlayer{{
 					ID:    aliceID,
 					Name:  `alice`,
 					Color: `red`,
 				}, {
-					ID:    bobID,
-					Name:  `bob`,
+					ID:    daveID,
+					Name:  `dave`,
 					Color: `blue`,
 				}},
-				Created:  time.Time{},
-				LastMove: time.Time{},
+				Created:  t1,
+				LastMove: t2,
 			}, {
 				GameID: 456,
 				Players: []ActiveGamePlayer{{
@@ -161,17 +172,17 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					Name:  `chelsea`,
 					Color: `blue`,
 				}},
-				Created:  time.Time{},
-				LastMove: time.Time{},
+				Created:  t1,
+				LastMove: t1,
 			}, {
-				GameID: 789,
+				GameID: 123,
 				Players: []ActiveGamePlayer{{
 					ID:    aliceID,
 					Name:  `alice`,
 					Color: `red`,
 				}, {
-					ID:    daveID,
-					Name:  `dave`,
+					ID:    bobID,
+					Name:  `bob`,
 					Color: `blue`,
 				}},
 				Created:  time.Time{},

--- a/server/persistence/memory/memory_service_game.go
+++ b/server/persistence/memory/memory_service_game.go
@@ -109,7 +109,8 @@ func validateGameState(savedGames []model.Game, newGameState model.Game) error {
 		if len(savedActions) != len(myKnownActions) {
 			return persistence.ErrGameActionsOutOfOrder
 		}
-		for ai, a := range savedActions {
+		for ai := range savedActions {
+			a := savedActions[ai]
 			if a.ID != myKnownActions[ai].ID || a.Overcomes != myKnownActions[ai].Overcomes {
 				return persistence.ErrGameActionsOutOfOrder
 			}

--- a/server/persistence/mongodb/mongodb_service_game.go
+++ b/server/persistence/mongodb/mongodb_service_game.go
@@ -269,7 +269,8 @@ func validateGameState(savedGames []model.Game, newGameState model.Game) error {
 		if len(savedActions) != len(myKnownActions) {
 			return persistence.ErrGameActionsOutOfOrder
 		}
-		for ai, a := range savedActions {
+		for ai := range savedActions {
+			a := savedActions[ai]
 			if a.ID != myKnownActions[ai].ID || a.Overcomes != myKnownActions[ai].Overcomes {
 				return persistence.ErrGameActionsOutOfOrder
 			}

--- a/server/persistence/mysql/consts.go
+++ b/server/persistence/mysql/consts.go
@@ -7,11 +7,11 @@ import (
 )
 
 const (
-	maxPlayerUUIDLen    = 255
-	maxPlayerUUIDLenStr = `255`
+	maxPlayerUUIDLen    = 191
+	maxPlayerUUIDLenStr = `191`
 
-	maxPlayerNameLen    = 255
-	maxPlayerNameLenStr = `255`
+	maxPlayerNameLen    = 191
+	maxPlayerNameLenStr = `191`
 
 	maxGameID = model.GameID(math.MaxUint32)
 )

--- a/server/persistence/mysql/games.go
+++ b/server/persistence/mysql/games.go
@@ -41,7 +41,7 @@ const (
 		Phase TINYINT UNSIGNED,
 		CutCard SMALLINT,
 		Crib INT,
-		CurrentDealer VARCHAR(` + maxPlayerUUIDLenStr + `),
+		CurrentDealer VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
 		BlockingPlayers BLOB,
 		Hands BLOB,
 		PeggedCards BLOB,
@@ -51,10 +51,10 @@ const (
 
 	createGamePlayersTable = `CREATE TABLE IF NOT EXISTS GamePlayers (
 		GameID INT UNSIGNED,
-		Player1ID VARCHAR(` + maxPlayerUUIDLenStr + `) NOT NULL,
-		Player2ID VARCHAR(` + maxPlayerUUIDLenStr + `) NOT NULL,
-		Player3ID VARCHAR(` + maxPlayerUUIDLenStr + `),
-		Player4ID VARCHAR(` + maxPlayerUUIDLenStr + `),
+		Player1ID VARCHAR(` + maxPlayerUUIDLenStr + `) NOT NULL COLLATE utf8_unicode_ci,
+		Player2ID VARCHAR(` + maxPlayerUUIDLenStr + `) NOT NULL COLLATE utf8_unicode_ci,
+		Player3ID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
+		Player4ID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
 		PRIMARY KEY (GameID)
 	) ENGINE = INNODB;`
 

--- a/server/persistence/mysql/games.go
+++ b/server/persistence/mysql/games.go
@@ -41,7 +41,7 @@ const (
 		Phase TINYINT UNSIGNED,
 		CutCard SMALLINT,
 		Crib INT,
-		CurrentDealer VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
+		CurrentDealer VARCHAR(` + maxPlayerUUIDLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs,
 		BlockingPlayers BLOB,
 		Hands BLOB,
 		PeggedCards BLOB,
@@ -51,10 +51,10 @@ const (
 
 	createGamePlayersTable = `CREATE TABLE IF NOT EXISTS GamePlayers (
 		GameID INT UNSIGNED,
-		Player1ID VARCHAR(` + maxPlayerUUIDLenStr + `) NOT NULL COLLATE utf8_unicode_ci,
-		Player2ID VARCHAR(` + maxPlayerUUIDLenStr + `) NOT NULL COLLATE utf8_unicode_ci,
-		Player3ID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
-		Player4ID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
+		Player1ID VARCHAR(` + maxPlayerUUIDLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
+		Player2ID VARCHAR(` + maxPlayerUUIDLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL,
+		Player3ID VARCHAR(` + maxPlayerUUIDLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs,
+		Player4ID VARCHAR(` + maxPlayerUUIDLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs,
 		PRIMARY KEY (GameID)
 	) ENGINE = INNODB;`
 

--- a/server/persistence/mysql/interaction.go
+++ b/server/persistence/mysql/interaction.go
@@ -11,7 +11,7 @@ import (
 const (
 	// Interactions stores the json-serialized InteractionMeans for a given player/mode
 	createInteractionTable = `CREATE TABLE IF NOT EXISTS Interactions (
-		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
+		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs,
 		Mode INT,
 		Means BLOB,
 		PRIMARY KEY (PlayerID)

--- a/server/persistence/mysql/interaction.go
+++ b/server/persistence/mysql/interaction.go
@@ -11,7 +11,7 @@ import (
 const (
 	// Interactions stores the json-serialized InteractionMeans for a given player/mode
 	createInteractionTable = `CREATE TABLE IF NOT EXISTS Interactions (
-		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `),
+		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
 		Mode INT,
 		Means BLOB,
 		PRIMARY KEY (PlayerID)

--- a/server/persistence/mysql/mysql.go
+++ b/server/persistence/mysql/mysql.go
@@ -28,6 +28,8 @@ func NewFactory(ctx context.Context, config Config) (persistence.DBFactory, erro
 	}
 	if len(config.DSNParams) > 0 {
 		dsn += `?` + config.DSNParams
+	} else {
+		dsn += `?parseTime=true`
 	}
 	db, err := sql.Open(`mysql`, dsn)
 	if err != nil {

--- a/server/persistence/mysql/mysql.go
+++ b/server/persistence/mysql/mysql.go
@@ -28,8 +28,6 @@ func NewFactory(ctx context.Context, config Config) (persistence.DBFactory, erro
 	}
 	if len(config.DSNParams) > 0 {
 		dsn += `?` + config.DSNParams
-	} else {
-		dsn += `?parseTime=true`
 	}
 	db, err := sql.Open(`mysql`, dsn)
 	if err != nil {

--- a/server/persistence/mysql/players.go
+++ b/server/persistence/mysql/players.go
@@ -11,8 +11,8 @@ const (
 	// Players stores info about Players that we need to keep.
 	// The default PreferredInteractionMode should be equal to int(interaction.UnsetMode)
 	createPlayersTable = `CREATE TABLE IF NOT EXISTS Players (
-		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `),
-		Name VARCHAR(` + maxPlayerNameLenStr + `),
+		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
+		Name VARCHAR(` + maxPlayerNameLenStr + `) COLLATE utf8_unicode_ci,
 		PreferredInteractionMode INT DEFAULT 0,
 		PRIMARY KEY (PlayerID)
 	) ENGINE = INNODB;`
@@ -21,7 +21,7 @@ const (
 	// The default Color should match int(model.UnsetColor) for player colors
 	createGamePlayerColorsTable = `CREATE TABLE IF NOT EXISTS GamePlayerColors (
 		GameID INT UNSIGNED,
-		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `),
+		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
 		Color TINYINT UNSIGNED DEFAULT 0,
 		PRIMARY KEY (GameID, PlayerID)
 	) ENGINE = INNODB;`

--- a/server/persistence/mysql/players.go
+++ b/server/persistence/mysql/players.go
@@ -11,8 +11,8 @@ const (
 	// Players stores info about Players that we need to keep.
 	// The default PreferredInteractionMode should be equal to int(interaction.UnsetMode)
 	createPlayersTable = `CREATE TABLE IF NOT EXISTS Players (
-		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
-		Name VARCHAR(` + maxPlayerNameLenStr + `) COLLATE utf8_unicode_ci,
+		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs,
+		Name VARCHAR(` + maxPlayerNameLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs,
 		PreferredInteractionMode INT DEFAULT 0,
 		PRIMARY KEY (PlayerID)
 	) ENGINE = INNODB;`
@@ -21,7 +21,7 @@ const (
 	// The default Color should match int(model.UnsetColor) for player colors
 	createGamePlayerColorsTable = `CREATE TABLE IF NOT EXISTS GamePlayerColors (
 		GameID INT UNSIGNED,
-		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) COLLATE utf8_unicode_ci,
+		PlayerID VARCHAR(` + maxPlayerUUIDLenStr + `) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs,
 		Color TINYINT UNSIGNED DEFAULT 0,
 		PRIMARY KEY (GameID, PlayerID)
 	) ENGINE = INNODB;`

--- a/server/persistence/mysql/test_utils.go
+++ b/server/persistence/mysql/test_utils.go
@@ -9,7 +9,7 @@ func GetTestConfig() Config {
 		DSNHost:        `localhost`,
 		DSNPort:        3306,
 		DatabaseName:   `testing_cribbage`,
-		DSNParams:      ``,
+		DSNParams:      `parseTime=true`,
 		RunCreateStmts: true,
 	}
 }
@@ -21,7 +21,7 @@ func GetTestConfigForLocal() Config {
 		DSNHost:        `127.0.0.1`,
 		DSNPort:        3306,
 		DatabaseName:   `testing_cribbage`,
-		DSNParams:      ``,
+		DSNParams:      `parseTime=true`,
 		RunCreateStmts: true,
 	}
 }

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -3,6 +3,7 @@ package persistence_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,6 +93,10 @@ func checkPersistedGame(t *testing.T, db persistence.DB, expGame model.Game) {
 	if len(actGame.Actions) == 0 {
 		expGame.Actions = nil
 		actGame.Actions = nil
+	}
+	for i := range actGame.Actions {
+		assert.NotEqual(t, time.Time{}, actGame.Actions[i].TimeStamp)
+		actGame.Actions[i].TimeStamp = time.Time{}
 	}
 	assert.Equal(t, expGame, actGame)
 }

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -29,12 +29,13 @@ const (
 
 var (
 	tests = map[string]dbTest{
-		`createPlayer`:          testCreatePlayer,
-		`saveGame`:              testCreateGame,
-		`resaveGame`:            testSaveGameMultipleTimes,
-		`saveGameMissingAction`: testSaveGameWithMissingAction,
-		`saveInteraction`:       testSaveInteraction,
-		`addColorToGame`:        testAddPlayerColorToGame,
+		`createPlayer`:                  testCreatePlayer,
+		`createPlayersWithSimilarNames`: testCreatePlayersWithSimilarNames,
+		`saveGame`:                      testCreateGame,
+		`resaveGame`:                    testSaveGameMultipleTimes,
+		`saveGameMissingAction`:         testSaveGameWithMissingAction,
+		`saveInteraction`:               testSaveInteraction,
+		`addColorToGame`:                testAddPlayerColorToGame,
 	}
 )
 
@@ -129,6 +130,25 @@ func TestDB(t *testing.T) {
 			t.Run(string(dbName)+`:`+testName, func(t1 *testing.T) { testFn(t1, dbName, db) })
 		}
 	}
+}
+
+func testCreatePlayersWithSimilarNames(t *testing.T, name dbName, db persistence.DB) {
+	p1 := model.Player{
+		ID:    model.PlayerID(`alice`),
+		Name:  `alice`,
+		Games: map[model.GameID]model.PlayerColor{},
+	}
+
+	assert.NoError(t, db.CreatePlayer(p1))
+
+	p2 := model.Player{
+		ID:    model.PlayerID(`Alice`),
+		Name:  `Alice`,
+		Games: map[model.GameID]model.PlayerColor{},
+	}
+
+	assert.NotEqual(t, p1.ID, p2.ID)
+	assert.NoError(t, db.CreatePlayer(p2))
 }
 
 func testCreatePlayer(t *testing.T, name dbName, db persistence.DB) {

--- a/server/setup.go
+++ b/server/setup.go
@@ -24,7 +24,7 @@ var (
 	dsnPassword = flag.String(`dsn_password`, ``, `The password for the user for the MySQL DB`)
 	dsnHost     = flag.String(`dsn_host`, `127.0.0.1`, `The host for the MySQL DB`)
 	dsnPort     = flag.Int(`dsn_port`, 3306, `The port for the MySQL DB`)
-	dsnParams   = flag.String(`dsn_params`, ``, `The params for the MySQL DB`)
+	dsnParams   = flag.String(`dsn_params`, `parseTime=true`, `The params for the MySQL DB`)
 	mysqlDBName = flag.String(`mysql_db`, `cribbage`, `The name of the Database to connect to in mysql`)
 
 	createTables = flag.Bool(`mysql_create_tables`, false, `Set to true when you want to create tables on startup.`)

--- a/server/setup.go
+++ b/server/setup.go
@@ -71,9 +71,6 @@ func getDBFactory(ctx context.Context, cfg factoryConfig) (persistence.DBFactory
 			DSNParams:      *dsnParams,
 			RunCreateStmts: cfg.canRunCreateStmts && *createTables,
 		}
-		if cfg.RunCreateStmts {
-			cfg.DatabaseName = ``
-		}
 		log.Println("Creating mysql factory")
 		log.Printf("  len(User): %d\n", len(cfg.DSNUser))
 		log.Printf("  empty Password: %v\n", cfg.DSNPassword == ``)

--- a/server/setup.go
+++ b/server/setup.go
@@ -71,6 +71,9 @@ func getDBFactory(ctx context.Context, cfg factoryConfig) (persistence.DBFactory
 			DSNParams:      *dsnParams,
 			RunCreateStmts: cfg.canRunCreateStmts && *createTables,
 		}
+		if cfg.RunCreateStmts {
+			cfg.DatabaseName = ``
+		}
 		log.Println("Creating mysql factory")
 		log.Printf("  len(User): %d\n", len(cfg.DSNUser))
 		log.Printf("  empty Password: %v\n", cfg.DSNPassword == ``)


### PR DESCRIPTION
## What broke / What you're adding
Add timestamp to actions.
Use a case-sensitive collation.

## How you did it

Put a column on the `Games` mysql DB table that defaults to current time. This should be "good enough" to tell us when a game was started and when the last move was.

I learned a lot from [this article](https://mathiasbynens.be/notes/mysql-utf8mb4) and [this stack overflow](https://stackoverflow.com/questions/54885178/whats-the-difference-between-utf8-unicode-ci-and-utf8mb4-0900-ai-ci) about collations. 

## How to test it and how to try to break it
Look at the active games table for games that have moves. See timestamps set now.
Add a player `dave` and another `Dave`. See them be different.