### PR TITLE
implement the suggestion hand logic only on the server

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.27
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.29
 
           # Optional: golangci-lint command line arguments.
           # args: ./the-only-dir-to-analyze/...

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ playerlogs/
 data/
 
 .DS_Store
+.vscode/
 
 # wasm output
 assets/wasm/wa_output.wasm

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY server server
 COPY main.go main.go
 
 # Build the server's binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/cribbageServer main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags prod -o /bin/cribbageServer main.go
 
 # build environment
 FROM node:14.3.0-alpine as react

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ serve: DSN_USER ?= root
 serve: DSN_PW ?= ""
 serve: DSN_HOST ?= "127.0.0.1"
 serve: ## Sets up the server locally with default options
-	go run main.go --dsn_user="$(DSN_USER)" --dsn_password="$(DSN_PW)" --dsn_host="$(DSN_HOST)"
+	go run -tags=prod main.go --dsn_user="$(DSN_USER)" --dsn_password="$(DSN_PW)" --dsn_host="$(DSN_HOST)"
 
 .PHONY: dockerbuild
 dockerbuild: ## Builds the docker image
@@ -58,4 +58,4 @@ dockerrunlocal: ## Runs the latest tag of the built docker image locally on port
 
 .PHONY: wasm
 wasm: ## Builds the wasm output for the gowasm client
-	GOOS=js GOARCH=wasm go build -o assets/wasm/wa_output.wasm github.com/joshprzybyszewski/cribbage/wasm
+	GOOS=js GOARCH=wasm go build -tags prod -o assets/wasm/wa_output.wasm github.com/joshprzybyszewski/cribbage/wasm

--- a/logic/strategy/calculated_crib.go
+++ b/logic/strategy/calculated_crib.go
@@ -1,84 +1,64 @@
 package strategy
 
 import (
-	"errors"
-
-	"github.com/joshprzybyszewski/cribbage/logic/scorer"
+	"github.com/joshprzybyszewski/cribbage/logic/suggestions"
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
 // GiveCribHighestPotential gives the crib the highest potential pointed crib
 func GiveCribHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	isBetter := func(old, new float64) bool { return new > old }
+	isBetter := func(old, new model.TossStats) bool {
+		if old == nil {
+			return true
+		}
+		if new == nil {
+			return false
+		}
+		if new.Avg() > old.Avg() {
+			return true
+		}
+		return new.Max() > old.Max()
+	}
 	return getBestPotentialCrib(hand, isBetter)
 }
 
 // GiveCribLowestPotential gives the crib the lowest potential pointed hand
 func GiveCribLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	isBetter := func(old, new float64) bool { return new < old }
+	isBetter := func(old, new model.TossStats) bool {
+		if old == nil {
+			return true
+		}
+		if new == nil {
+			return false
+		}
+		if new.Avg() < old.Avg() {
+			return true
+		}
+		return new.Min() < old.Min()
+	}
 	return getBestPotentialCrib(hand, isBetter)
 }
 
-func getBestPotentialCrib(hand []model.Card, isBetter func(old, new float64) bool) ([]model.Card, error) {
-	if len(hand) > 6 || len(hand) <= 4 {
-		return nil, errors.New(`hand size must be between 4 and 6`)
-	}
-
-	lenDeposit := len(hand) - 4
-	bestCrib := make([]model.Card, 0, lenDeposit)
-	bestPotential := 0.0
-
-	allDeposits, err := chooseFrom(lenDeposit, hand)
+func getBestPotentialCrib(
+	hand []model.Card,
+	isBetter func(old, new model.TossStats) bool,
+) ([]model.Card, error) {
+	sums, err := suggestions.GetAllTosses(hand)
 	if err != nil {
 		return nil, err
 	}
 
-	seen := map[model.Card]struct{}{}
-	for _, c := range hand {
-		seen[c] = struct{}{}
-	}
+	lenDeposit := len(hand) - 4
+	bestThrow := make([]model.Card, 0, lenDeposit)
+	var prevBest model.TossStats
 
-	for i, dep := range allDeposits {
-		p := getPotentialForDeposit(seen, dep)
-		if i == 0 || isBetter(bestPotential, p) {
-			bestCrib = bestCrib[:0]
-			bestCrib = append(bestCrib, dep...)
-			bestPotential = p
+	for _, s := range sums {
+		if isBetter(prevBest, s.CribStats) {
+			bestThrow = bestThrow[:0]
+			bestThrow = append(bestThrow, s.Tossed...)
+			prevBest = s.CribStats
 		}
 	}
 
-	return bestCrib, nil
-}
-
-func getPotentialForDeposit(prevSeen map[model.Card]struct{}, cribDeposit []model.Card) float64 {
-	seen := map[model.Card]struct{}{}
-	for k := range prevSeen {
-		seen[k] = struct{}{}
-	}
-	for _, c := range cribDeposit {
-		seen[c] = struct{}{}
-	}
-
-	totalCribPoints := 0
-	totalHands := 0
-
-	for i := 0; i < 52; i++ {
-		lead := model.NewCardFromNumber(i)
-		if _, ok := seen[lead]; ok {
-			continue
-		}
-
-		seen[lead] = struct{}{}
-
-		options := otherOptions(4-len(cribDeposit), seen)
-
-		for _, o := range options {
-			totalCribPoints += scorer.CribPoints(lead, append(o, cribDeposit...))
-			totalHands++
-		}
-
-		delete(seen, lead)
-	}
-
-	return float64(totalCribPoints) / float64(totalHands)
+	return bestThrow, nil
 }

--- a/logic/strategy/calculated_crib.go
+++ b/logic/strategy/calculated_crib.go
@@ -4,16 +4,36 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
-func cribStatsGetter(s model.TossSummary) model.TossStats {
-	return s.CribStats
+var _ handEvaluator = (*highestCribEvaluator)(nil)
+
+type highestCribEvaluator struct{}
+
+func (*highestCribEvaluator) getStats(ts model.TossSummary) model.TossStats {
+	return ts.CribStats
+}
+
+func (*highestCribEvaluator) isBetter(old, new model.TossStats) bool {
+	return willKeepHighestPotential(old, new)
 }
 
 // GiveCribHighestPotential gives the crib the highest potential pointed crib
 func GiveCribHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	return getEvaluatedHand(hand, cribStatsGetter, willKeepHighestPotential)
+	return getEvaluatedHand(hand, &highestCribEvaluator{})
+}
+
+var _ handEvaluator = (*lowestCribEvaluator)(nil)
+
+type lowestCribEvaluator struct{}
+
+func (*lowestCribEvaluator) getStats(ts model.TossSummary) model.TossStats {
+	return ts.CribStats
+}
+
+func (*lowestCribEvaluator) isBetter(old, new model.TossStats) bool {
+	return willKeepLowestPotential(old, new)
 }
 
 // GiveCribLowestPotential gives the crib the lowest potential pointed hand
 func GiveCribLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	return getEvaluatedHand(hand, cribStatsGetter, willKeepLowestPotential)
+	return getEvaluatedHand(hand, &lowestCribEvaluator{})
 }

--- a/logic/strategy/calculated_crib.go
+++ b/logic/strategy/calculated_crib.go
@@ -1,64 +1,19 @@
 package strategy
 
 import (
-	"github.com/joshprzybyszewski/cribbage/logic/suggestions"
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
+func cribStatsGetter(s model.TossSummary) model.TossStats {
+	return s.CribStats
+}
+
 // GiveCribHighestPotential gives the crib the highest potential pointed crib
 func GiveCribHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	isBetter := func(old, new model.TossStats) bool {
-		if old == nil {
-			return true
-		}
-		if new == nil {
-			return false
-		}
-		if new.Avg() > old.Avg() {
-			return true
-		}
-		return new.Max() > old.Max()
-	}
-	return getBestPotentialCrib(hand, isBetter)
+	return getEvaluatedHand(hand, cribStatsGetter, willKeepHighestPotential)
 }
 
 // GiveCribLowestPotential gives the crib the lowest potential pointed hand
 func GiveCribLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	isBetter := func(old, new model.TossStats) bool {
-		if old == nil {
-			return true
-		}
-		if new == nil {
-			return false
-		}
-		if new.Avg() < old.Avg() {
-			return true
-		}
-		return new.Min() < old.Min()
-	}
-	return getBestPotentialCrib(hand, isBetter)
-}
-
-func getBestPotentialCrib(
-	hand []model.Card,
-	isBetter func(old, new model.TossStats) bool,
-) ([]model.Card, error) {
-	sums, err := suggestions.GetAllTosses(hand)
-	if err != nil {
-		return nil, err
-	}
-
-	lenDeposit := len(hand) - 4
-	bestThrow := make([]model.Card, 0, lenDeposit)
-	var prevBest model.TossStats
-
-	for _, s := range sums {
-		if isBetter(prevBest, s.CribStats) {
-			bestThrow = bestThrow[:0]
-			bestThrow = append(bestThrow, s.Tossed...)
-			prevBest = s.CribStats
-		}
-	}
-
-	return bestThrow, nil
+	return getEvaluatedHand(hand, cribStatsGetter, willKeepLowestPotential)
 }

--- a/logic/strategy/calculated_crib.go
+++ b/logic/strategy/calculated_crib.go
@@ -4,36 +4,12 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
-var _ handEvaluator = (*highestCribEvaluator)(nil)
-
-type highestCribEvaluator struct{}
-
-func (*highestCribEvaluator) getStats(ts model.TossSummary) model.TossStats {
-	return ts.CribStats
-}
-
-func (*highestCribEvaluator) isBetter(old, new model.TossStats) bool {
-	return willKeepHighestPotential(old, new)
-}
-
 // GiveCribHighestPotential gives the crib the highest potential pointed crib
 func GiveCribHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	return getEvaluatedHand(hand, &highestCribEvaluator{})
-}
-
-var _ handEvaluator = (*lowestCribEvaluator)(nil)
-
-type lowestCribEvaluator struct{}
-
-func (*lowestCribEvaluator) getStats(ts model.TossSummary) model.TossStats {
-	return ts.CribStats
-}
-
-func (*lowestCribEvaluator) isBetter(old, new model.TossStats) bool {
-	return willKeepLowestPotential(old, new)
+	return getEvaluatedHand(hand, newTossEvaluator(false, highestIsBetter))
 }
 
 // GiveCribLowestPotential gives the crib the lowest potential pointed hand
 func GiveCribLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	return getEvaluatedHand(hand, &lowestCribEvaluator{})
+	return getEvaluatedHand(hand, newTossEvaluator(false, lowestIsBetter))
 }

--- a/logic/strategy/calculated_hand.go
+++ b/logic/strategy/calculated_hand.go
@@ -1,79 +1,64 @@
 package strategy
 
 import (
-	"errors"
-
-	"github.com/joshprzybyszewski/cribbage/logic/scorer"
+	"github.com/joshprzybyszewski/cribbage/logic/suggestions"
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
 // KeepHandHighestPotential will keep the hand with the highest potential score
 func KeepHandHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	isBetter := func(old, new float64) bool { return new > old }
+	isBetter := func(old, new model.TossStats) bool {
+		if old == nil {
+			return true
+		}
+		if new == nil {
+			return false
+		}
+		if new.Avg() > old.Avg() {
+			return true
+		}
+		return new.Max() > old.Max()
+	}
 	return getBestPotentialHand(hand, isBetter)
 }
 
 // KeepHandLowestPotential will keep the hand with the lowest potential score
 func KeepHandLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	isBetter := func(old, new float64) bool { return new < old }
+	isBetter := func(old, new model.TossStats) bool {
+		if old == nil {
+			return true
+		}
+		if new == nil {
+			return false
+		}
+		if new.Avg() < old.Avg() {
+			return true
+		}
+		return new.Min() < old.Min()
+	}
 	return getBestPotentialHand(hand, isBetter)
 }
 
-func getBestPotentialHand(hand []model.Card, isBetter func(old, new float64) bool) ([]model.Card, error) {
-	if len(hand) > 6 || len(hand) <= 4 {
-		return nil, errors.New(`hand size must be between 4 and 6`)
-	}
-
-	bestHand := make([]model.Card, 0, 4)
-	bestPotential := 0.0
-
-	allHands, err := chooseFrom(4, hand)
+func getBestPotentialHand(
+	hand []model.Card,
+	isBetter func(old, new model.TossStats) bool,
+) ([]model.Card, error) {
+	sums, err := suggestions.GetAllTosses(hand)
 	if err != nil {
 		return nil, err
 	}
 
-	seen := map[model.Card]struct{}{}
-	for _, c := range hand {
-		seen[c] = struct{}{}
-	}
+	lenDeposit := len(hand) - 4
+	bestThrow := make([]model.Card, 0, lenDeposit)
+	var prevBest model.TossStats
 
-	for i, h := range allHands {
-		p := getHandPotentialForCribDeposit(seen, h)
-		if i == 0 || isBetter(bestPotential, p) {
-			bestHand = bestHand[:0]
-			bestHand = append(bestHand, h...)
-			bestPotential = p
+	for _, s := range sums {
+		if isBetter(prevBest, s.HandStats) {
+			bestThrow = bestThrow[:0]
+			bestThrow = append(bestThrow, s.Tossed...)
+			prevBest = s.HandStats
 		}
 	}
 
-	return without(hand, bestHand), nil
-}
-
-func getHandPotentialForCribDeposit(prevSeen map[model.Card]struct{}, hand []model.Card) float64 {
-	seen := map[model.Card]struct{}{}
-	for k := range prevSeen {
-		seen[k] = struct{}{}
-	}
-	for _, c := range hand {
-		seen[c] = struct{}{}
-	}
-
-	totalHandPoints := 0
-	totalHands := 0
-
-	for i := 0; i < 52; i++ {
-		lead := model.NewCardFromNumber(i)
-		if _, ok := seen[lead]; ok {
-			continue
-		}
-
-		seen[lead] = struct{}{}
-
-		totalHandPoints += scorer.HandPoints(lead, hand)
-		totalHands++
-
-		delete(seen, lead)
-	}
-
-	return float64(totalHandPoints) / float64(totalHands)
+	return bestThrow, nil
 }

--- a/logic/strategy/calculated_hand.go
+++ b/logic/strategy/calculated_hand.go
@@ -8,12 +8,37 @@ func handStatsGetter(s model.TossSummary) model.TossStats {
 	return s.HandStats
 }
 
+var _ handEvaluator = (*highestHandEvaluator)(nil)
+
+type highestHandEvaluator struct{}
+
+func (*highestHandEvaluator) getStats(ts model.TossSummary) model.TossStats {
+	return ts.HandStats
+
+}
+
+func (*highestHandEvaluator) isBetter(old, new model.TossStats) bool {
+	return willKeepHighestPotential(old, new)
+}
+
 // KeepHandHighestPotential will keep the hand with the highest potential score
 func KeepHandHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	return getEvaluatedHand(hand, handStatsGetter, willKeepHighestPotential)
+	return getEvaluatedHand(hand, &highestHandEvaluator{})
+}
+
+var _ handEvaluator = (*lowestHandEvaluator)(nil)
+
+type lowestHandEvaluator struct{}
+
+func (*lowestHandEvaluator) getStats(ts model.TossSummary) model.TossStats {
+	return ts.HandStats
+}
+
+func (*lowestHandEvaluator) isBetter(old, new model.TossStats) bool {
+	return willKeepLowestPotential(old, new)
 }
 
 // KeepHandLowestPotential will keep the hand with the lowest potential score
 func KeepHandLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	return getEvaluatedHand(hand, handStatsGetter, willKeepLowestPotential)
+	return getEvaluatedHand(hand, &lowestHandEvaluator{})
 }

--- a/logic/strategy/calculated_hand.go
+++ b/logic/strategy/calculated_hand.go
@@ -4,10 +4,6 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
-func handStatsGetter(s model.TossSummary) model.TossStats {
-	return s.HandStats
-}
-
 var _ handEvaluator = (*highestHandEvaluator)(nil)
 
 type highestHandEvaluator struct{}

--- a/logic/strategy/calculated_hand.go
+++ b/logic/strategy/calculated_hand.go
@@ -4,37 +4,12 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
-var _ handEvaluator = (*highestHandEvaluator)(nil)
-
-type highestHandEvaluator struct{}
-
-func (*highestHandEvaluator) getStats(ts model.TossSummary) model.TossStats {
-	return ts.HandStats
-
-}
-
-func (*highestHandEvaluator) isBetter(old, new model.TossStats) bool {
-	return willKeepHighestPotential(old, new)
-}
-
 // KeepHandHighestPotential will keep the hand with the highest potential score
 func KeepHandHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	return getEvaluatedHand(hand, &highestHandEvaluator{})
-}
-
-var _ handEvaluator = (*lowestHandEvaluator)(nil)
-
-type lowestHandEvaluator struct{}
-
-func (*lowestHandEvaluator) getStats(ts model.TossSummary) model.TossStats {
-	return ts.HandStats
-}
-
-func (*lowestHandEvaluator) isBetter(old, new model.TossStats) bool {
-	return willKeepLowestPotential(old, new)
+	return getEvaluatedHand(hand, newTossEvaluator(true, highestIsBetter))
 }
 
 // KeepHandLowestPotential will keep the hand with the lowest potential score
 func KeepHandLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	return getEvaluatedHand(hand, &lowestHandEvaluator{})
+	return getEvaluatedHand(hand, newTossEvaluator(true, lowestIsBetter))
 }

--- a/logic/strategy/calculated_hand.go
+++ b/logic/strategy/calculated_hand.go
@@ -1,64 +1,19 @@
 package strategy
 
 import (
-	"github.com/joshprzybyszewski/cribbage/logic/suggestions"
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
+func handStatsGetter(s model.TossSummary) model.TossStats {
+	return s.HandStats
+}
+
 // KeepHandHighestPotential will keep the hand with the highest potential score
 func KeepHandHighestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	isBetter := func(old, new model.TossStats) bool {
-		if old == nil {
-			return true
-		}
-		if new == nil {
-			return false
-		}
-		if new.Avg() > old.Avg() {
-			return true
-		}
-		return new.Max() > old.Max()
-	}
-	return getBestPotentialHand(hand, isBetter)
+	return getEvaluatedHand(hand, handStatsGetter, willKeepHighestPotential)
 }
 
 // KeepHandLowestPotential will keep the hand with the lowest potential score
 func KeepHandLowestPotential(_ int, hand []model.Card) ([]model.Card, error) {
-	isBetter := func(old, new model.TossStats) bool {
-		if old == nil {
-			return true
-		}
-		if new == nil {
-			return false
-		}
-		if new.Avg() < old.Avg() {
-			return true
-		}
-		return new.Min() < old.Min()
-	}
-	return getBestPotentialHand(hand, isBetter)
-}
-
-func getBestPotentialHand(
-	hand []model.Card,
-	isBetter func(old, new model.TossStats) bool,
-) ([]model.Card, error) {
-	sums, err := suggestions.GetAllTosses(hand)
-	if err != nil {
-		return nil, err
-	}
-
-	lenDeposit := len(hand) - 4
-	bestThrow := make([]model.Card, 0, lenDeposit)
-	var prevBest model.TossStats
-
-	for _, s := range sums {
-		if isBetter(prevBest, s.HandStats) {
-			bestThrow = bestThrow[:0]
-			bestThrow = append(bestThrow, s.Tossed...)
-			prevBest = s.HandStats
-		}
-	}
-
-	return bestThrow, nil
+	return getEvaluatedHand(hand, handStatsGetter, willKeepLowestPotential)
 }

--- a/logic/strategy/calculated_toss.go
+++ b/logic/strategy/calculated_toss.go
@@ -42,7 +42,7 @@ func getEvaluatedHand(
 	getStats func(model.TossSummary) model.TossStats,
 	isBetter func(old, new model.TossStats) bool,
 ) ([]model.Card, error) {
-	sums, err := suggestions.GetAllTosses(hand)
+	summaries, err := suggestions.GetAllTosses(hand)
 	if err != nil {
 		return nil, err
 	}
@@ -51,8 +51,8 @@ func getEvaluatedHand(
 	bestThrow := make([]model.Card, 0, lenDeposit)
 	var prevBest model.TossStats
 
-	for _, s := range sums {
-		stats := getStats(s)
+	for i := range summaries {
+		stats := getStats(summaries[i])
 		if isBetter(prevBest, stats) {
 			bestThrow = bestThrow[:0]
 			bestThrow = append(bestThrow, s.Tossed...)

--- a/logic/strategy/calculated_toss.go
+++ b/logic/strategy/calculated_toss.go
@@ -10,38 +10,6 @@ type handEvaluator interface {
 	isBetter(old, new model.TossStats) bool
 }
 
-func willKeepLowestPotential(old, new model.TossStats) bool {
-	if old == nil {
-		return true
-	}
-	if new == nil {
-		return false
-	}
-	if new.Median() != old.Median() {
-		return new.Median() < old.Median()
-	}
-	if new.Avg() != old.Avg() {
-		return new.Avg() < old.Avg()
-	}
-	return new.Min() < old.Min()
-}
-
-func willKeepHighestPotential(old, new model.TossStats) bool {
-	if old == nil {
-		return true
-	}
-	if new == nil {
-		return false
-	}
-	if new.Median() != old.Median() {
-		return new.Median() > old.Median()
-	}
-	if new.Avg() != old.Avg() {
-		return new.Avg() > old.Avg()
-	}
-	return new.Max() > old.Max()
-}
-
 func getEvaluatedHand(
 	hand []model.Card,
 	he handEvaluator,

--- a/logic/strategy/calculated_toss.go
+++ b/logic/strategy/calculated_toss.go
@@ -55,7 +55,7 @@ func getEvaluatedHand(
 		stats := getStats(summaries[i])
 		if isBetter(prevBest, stats) {
 			bestThrow = bestThrow[:0]
-			bestThrow = append(bestThrow, s.Tossed...)
+			bestThrow = append(bestThrow, summaries[i].Tossed...)
 			prevBest = stats
 		}
 	}

--- a/logic/strategy/calculated_toss.go
+++ b/logic/strategy/calculated_toss.go
@@ -1,0 +1,64 @@
+package strategy
+
+import (
+	"github.com/joshprzybyszewski/cribbage/logic/suggestions"
+	"github.com/joshprzybyszewski/cribbage/model"
+)
+
+func willKeepLowestPotential(old, new model.TossStats) bool {
+	if old == nil {
+		return true
+	}
+	if new == nil {
+		return false
+	}
+	if new.Median() != old.Median() {
+		return new.Median() < old.Median()
+	}
+	if new.Avg() != old.Avg() {
+		return new.Avg() < old.Avg()
+	}
+	return new.Min() < old.Min()
+}
+
+func willKeepHighestPotential(old, new model.TossStats) bool {
+	if old == nil {
+		return true
+	}
+	if new == nil {
+		return false
+	}
+	if new.Median() != old.Median() {
+		return new.Median() > old.Median()
+	}
+	if new.Avg() != old.Avg() {
+		return new.Avg() > old.Avg()
+	}
+	return new.Max() > old.Max()
+}
+
+func getEvaluatedHand(
+	hand []model.Card,
+	getStats func(model.TossSummary) model.TossStats,
+	isBetter func(old, new model.TossStats) bool,
+) ([]model.Card, error) {
+	sums, err := suggestions.GetAllTosses(hand)
+	if err != nil {
+		return nil, err
+	}
+
+	lenDeposit := len(hand) - 4
+	bestThrow := make([]model.Card, 0, lenDeposit)
+	var prevBest model.TossStats
+
+	for _, s := range sums {
+		stats := getStats(s)
+		if isBetter(prevBest, stats) {
+			bestThrow = bestThrow[:0]
+			bestThrow = append(bestThrow, s.Tossed...)
+			prevBest = stats
+		}
+	}
+
+	return bestThrow, nil
+}

--- a/logic/strategy/calculated_toss.go
+++ b/logic/strategy/calculated_toss.go
@@ -5,6 +5,11 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
+type handEvaluator interface {
+	getStats(model.TossSummary) model.TossStats
+	isBetter(old, new model.TossStats) bool
+}
+
 func willKeepLowestPotential(old, new model.TossStats) bool {
 	if old == nil {
 		return true
@@ -39,8 +44,7 @@ func willKeepHighestPotential(old, new model.TossStats) bool {
 
 func getEvaluatedHand(
 	hand []model.Card,
-	getStats func(model.TossSummary) model.TossStats,
-	isBetter func(old, new model.TossStats) bool,
+	he handEvaluator,
 ) ([]model.Card, error) {
 	summaries, err := suggestions.GetAllTosses(hand)
 	if err != nil {
@@ -52,8 +56,8 @@ func getEvaluatedHand(
 	var prevBest model.TossStats
 
 	for i := range summaries {
-		stats := getStats(summaries[i])
-		if isBetter(prevBest, stats) {
+		stats := he.getStats(summaries[i])
+		if he.isBetter(prevBest, stats) {
 			bestThrow = bestThrow[:0]
 			bestThrow = append(bestThrow, summaries[i].Tossed...)
 			prevBest = stats

--- a/logic/strategy/toss_evaluator.go
+++ b/logic/strategy/toss_evaluator.go
@@ -44,30 +44,38 @@ func (te *tossEvaluator) isBetter(old, new model.TossStats) bool {
 
 	switch te.kind {
 	case highestIsBetter:
-		if differentFloats(new.Median(), old.Median()) {
-			return new.Median() > old.Median()
-		}
-		if differentFloats(new.Avg(), old.Avg()) {
-			return new.Avg() > old.Avg()
-		}
-		if new.Max() != old.Max() {
-			return new.Max() > old.Max()
-		}
-		return new.Min() > old.Min()
+		return higherStats(old, new)
 
 	case lowestIsBetter:
-		if differentFloats(new.Median(), old.Median()) {
-			return new.Median() < old.Median()
-		}
-		if differentFloats(new.Avg(), old.Avg()) {
-			return new.Avg() < old.Avg()
-		}
-		if new.Min() != old.Min() {
-			return new.Min() < old.Min()
-		}
-		return new.Max() < old.Max()
+		return lowerStats(old, new)
 	}
 	return false
+}
+
+func higherStats(old, new model.TossStats) bool {
+	if differentFloats(new.Median(), old.Median()) {
+		return new.Median() > old.Median()
+	}
+	if differentFloats(new.Avg(), old.Avg()) {
+		return new.Avg() > old.Avg()
+	}
+	if new.Max() != old.Max() {
+		return new.Max() > old.Max()
+	}
+	return new.Min() > old.Min()
+}
+
+func lowerStats(old, new model.TossStats) bool {
+	if differentFloats(new.Median(), old.Median()) {
+		return new.Median() < old.Median()
+	}
+	if differentFloats(new.Avg(), old.Avg()) {
+		return new.Avg() < old.Avg()
+	}
+	if new.Min() != old.Min() {
+		return new.Min() < old.Min()
+	}
+	return new.Max() < old.Max()
 }
 
 func differentFloats(

--- a/logic/strategy/toss_evaluator.go
+++ b/logic/strategy/toss_evaluator.go
@@ -35,11 +35,44 @@ func (te *tossEvaluator) getStats(ts model.TossSummary) model.TossStats {
 }
 
 func (te *tossEvaluator) isBetter(old, new model.TossStats) bool {
+	if old == nil {
+		return true
+	}
+	if new == nil {
+		return false
+	}
+
 	switch te.kind {
 	case highestIsBetter:
-		return willKeepHighestPotential(old, new)
+		if differentFloats(new.Median(), old.Median()) {
+			return new.Median() > old.Median()
+		}
+		if differentFloats(new.Avg(), old.Avg()) {
+			return new.Avg() > old.Avg()
+		}
+		if new.Max() != old.Max() {
+			return new.Max() > old.Max()
+		}
+		return new.Min() > old.Min()
+
 	case lowestIsBetter:
-		return willKeepLowestPotential(old, new)
+		if differentFloats(new.Median(), old.Median()) {
+			return new.Median() < old.Median()
+		}
+		if differentFloats(new.Avg(), old.Avg()) {
+			return new.Avg() < old.Avg()
+		}
+		if new.Min() != old.Min() {
+			return new.Min() < old.Min()
+		}
+		return new.Max() < old.Max()
 	}
 	return false
+}
+
+func differentFloats(
+	a, b float64,
+) bool {
+	epsilon := 0.001
+	return a-b > epsilon || b-a > epsilon
 }

--- a/logic/strategy/toss_evaluator.go
+++ b/logic/strategy/toss_evaluator.go
@@ -1,0 +1,45 @@
+package strategy
+
+import "github.com/joshprzybyszewski/cribbage/model"
+
+type betterKind int
+
+const (
+	highestIsBetter betterKind = 0
+	lowestIsBetter  betterKind = 1
+)
+
+var _ handEvaluator = (*tossEvaluator)(nil)
+
+type tossEvaluator struct {
+	forHand bool
+	kind    betterKind
+}
+
+func newTossEvaluator(
+	forHand bool,
+	kind betterKind,
+) handEvaluator {
+	return &tossEvaluator{
+		forHand: forHand,
+		kind:    kind,
+	}
+}
+
+func (te *tossEvaluator) getStats(ts model.TossSummary) model.TossStats {
+	if te.forHand {
+		return ts.HandStats
+	}
+	return ts.CribStats
+
+}
+
+func (te *tossEvaluator) isBetter(old, new model.TossStats) bool {
+	switch te.kind {
+	case highestIsBetter:
+		return willKeepHighestPotential(old, new)
+	case lowestIsBetter:
+		return willKeepLowestPotential(old, new)
+	}
+	return false
+}

--- a/logic/suggestions/handToss.go
+++ b/logic/suggestions/handToss.go
@@ -10,8 +10,8 @@ import (
 func GetAllTosses(
 	hand []model.Card,
 ) ([]model.TossSummary, error) {
-	if len(hand) > 6 || len(hand) <= 4 {
-		return nil, errors.New(`hand size must be between 4 and 6`)
+	if len(hand) > 6 || len(hand) < 4 {
+		return nil, errors.New(`hand size must be either 5 or 6`)
 	}
 
 	allHands, err := chooseNFrom(4, hand)
@@ -19,13 +19,13 @@ func GetAllTosses(
 		return nil, err
 	}
 
-	sums := []model.TossSummary{}
+	summaries := []model.TossSummary{}
 
 	for _, h := range allHands {
 		tossed := without(hand, h)
 		handStats, cribStats := getStatsForHand(h, tossed)
 
-		sums = append(sums, model.TossSummary{
+		summaries = append(summaries, model.TossSummary{
 			Kept:      h,
 			Tossed:    tossed,
 			HandStats: handStats,
@@ -33,7 +33,7 @@ func GetAllTosses(
 		})
 	}
 
-	return sums, nil
+	return summaries, nil
 }
 
 func getStatsForHand(

--- a/logic/suggestions/handToss.go
+++ b/logic/suggestions/handToss.go
@@ -1,0 +1,72 @@
+package suggestions
+
+import (
+	"errors"
+
+	"github.com/joshprzybyszewski/cribbage/logic/scorer"
+	"github.com/joshprzybyszewski/cribbage/model"
+)
+
+func GetAllTosses(
+	hand []model.Card,
+) ([]model.TossSummary, error) {
+	if len(hand) > 6 || len(hand) <= 4 {
+		return nil, errors.New(`hand size must be between 4 and 6`)
+	}
+
+	allHands, err := chooseNFrom(4, hand)
+	if err != nil {
+		return nil, err
+	}
+
+	sums := []model.TossSummary{}
+
+	for _, h := range allHands {
+		tossed := without(hand, h)
+		handStats, cribStats := getStatsForHand(h, tossed)
+
+		sums = append(sums, model.TossSummary{
+			Kept:      h,
+			Tossed:    tossed,
+			HandStats: handStats,
+			CribStats: cribStats,
+		})
+	}
+
+	return sums, nil
+}
+
+func getStatsForHand(
+	hand, tossed []model.Card,
+) (handStats, cribStats *tossStats) {
+	exclude := map[model.Card]struct{}{}
+	for _, c := range hand {
+		exclude[c] = struct{}{}
+	}
+	for _, c := range tossed {
+		exclude[c] = struct{}{}
+	}
+
+	handStats = &tossStats{}
+	cribStats = &tossStats{}
+	defer handStats.calculate()
+	defer cribStats.calculate()
+
+	for i := 0; i < 52; i++ {
+		lead := model.NewCardFromNumber(i)
+		if _, ok := exclude[lead]; ok {
+			continue
+		}
+
+		handStats.add(scorer.HandPoints(lead, hand))
+
+		exclude[lead] = struct{}{}
+		options := otherOptions(4-len(tossed), exclude)
+		for _, o := range options {
+			cribStats.add(scorer.CribPoints(lead, append(o, tossed...)))
+		}
+		delete(exclude, lead)
+	}
+
+	return handStats, cribStats
+}

--- a/logic/suggestions/handToss.go
+++ b/logic/suggestions/handToss.go
@@ -13,6 +13,9 @@ func GetAllTosses(
 	if len(hand) > 6 || len(hand) < 4 {
 		return nil, errors.New(`hand size must be either 5 or 6`)
 	}
+	if containsDuplicates(hand) {
+		return nil, errors.New(`hand contains duplicates`)
+	}
 
 	allHands, err := chooseNFrom(4, hand)
 	if err != nil {
@@ -69,4 +72,15 @@ func getStatsForHand(
 	}
 
 	return handStats, cribStats
+}
+
+func containsDuplicates(hand []model.Card) bool {
+	found := map[model.Card]struct{}{}
+	for _, c := range hand {
+		if _, ok := found[c]; ok {
+			return true
+		}
+		found[c] = struct{}{}
+	}
+	return false
 }

--- a/logic/suggestions/handToss.go
+++ b/logic/suggestions/handToss.go
@@ -53,19 +53,19 @@ func getStatsForHand(
 	defer cribStats.calculate()
 
 	for i := 0; i < 52; i++ {
-		lead := model.NewCardFromNumber(i)
-		if _, ok := exclude[lead]; ok {
+		cutCard := model.NewCardFromNumber(i)
+		if _, ok := exclude[cutCard]; ok {
 			continue
 		}
 
-		handStats.add(scorer.HandPoints(lead, hand))
+		handStats.add(scorer.HandPoints(cutCard, hand))
 
-		exclude[lead] = struct{}{}
+		exclude[cutCard] = struct{}{}
 		options := otherOptions(4-len(tossed), exclude)
 		for _, o := range options {
-			cribStats.add(scorer.CribPoints(lead, append(o, tossed...)))
+			cribStats.add(scorer.CribPoints(cutCard, append(o, tossed...)))
 		}
-		delete(exclude, lead)
+		delete(exclude, cutCard)
 	}
 
 	return handStats, cribStats

--- a/logic/suggestions/handToss_test.go
+++ b/logic/suggestions/handToss_test.go
@@ -182,7 +182,8 @@ func TestGetAllTosses(t *testing.T) {
 				network.ModelCardsFromStrings(tc.hand...),
 			)
 			require.NoError(t, err)
-			for i, actSum := range actSums {
+			for i, := range actSums {
+				actSum := actSums[i]
 				expSum := tc.expSummaries[i]
 				assert.Equal(t, expSum.Kept, actSum.Kept)
 				assert.Equal(t, expSum.Tossed, actSum.Tossed)

--- a/logic/suggestions/handToss_test.go
+++ b/logic/suggestions/handToss_test.go
@@ -80,12 +80,12 @@ func TestGetStatsForHand(t *testing.T) {
 				network.ModelCardsFromStrings(tc.tossed...),
 			)
 			assert.Equal(t, tc.expHandStats.Min(), actHand.Min())
-			assert.Equal(t, tc.expHandStats.Avg(), actHand.Avg())
-			assert.Equal(t, tc.expHandStats.Median(), actHand.Median())
+			assert.InEpsilon(t, tc.expHandStats.Avg(), actHand.Avg(), 0.001)
+			assert.InEpsilon(t, tc.expHandStats.Median(), actHand.Median(), 0.001)
 			assert.Equal(t, tc.expHandStats.Max(), actHand.Max())
 			assert.Equal(t, tc.expCribStats.Min(), actCrib.Min())
-			assert.Equal(t, tc.expCribStats.Avg(), actCrib.Avg())
-			assert.Equal(t, tc.expCribStats.Median(), actCrib.Median())
+			assert.InEpsilon(t, tc.expCribStats.Avg(), actCrib.Avg(), 0.001)
+			assert.InEpsilon(t, tc.expCribStats.Median(), actCrib.Median(), 0.001)
 			assert.Equal(t, tc.expCribStats.Max(), actCrib.Max())
 		})
 	}
@@ -178,22 +178,22 @@ func TestGetAllTosses(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			actSums, err := GetAllTosses(
+			actSumms, err := GetAllTosses(
 				network.ModelCardsFromStrings(tc.hand...),
 			)
 			require.NoError(t, err)
-			for i := range actSums {
-				actSum := actSums[i]
+			for i := range actSumms {
+				actSum := actSumms[i]
 				expSum := tc.expSummaries[i]
 				assert.Equal(t, expSum.Kept, actSum.Kept)
 				assert.Equal(t, expSum.Tossed, actSum.Tossed)
 				assert.Equal(t, expSum.HandStats.Min(), actSum.HandStats.Min())
-				assert.Equal(t, expSum.HandStats.Avg(), actSum.HandStats.Avg())
-				assert.Equal(t, expSum.HandStats.Median(), actSum.HandStats.Median())
+				assert.InEpsilon(t, expSum.HandStats.Avg(), actSum.HandStats.Avg(), 0.001)
+				assert.InEpsilon(t, expSum.HandStats.Median(), actSum.HandStats.Median(), 0.001)
 				assert.Equal(t, expSum.HandStats.Max(), actSum.HandStats.Max())
 				assert.Equal(t, expSum.CribStats.Min(), actSum.CribStats.Min())
-				assert.Equal(t, expSum.CribStats.Avg(), actSum.CribStats.Avg())
-				assert.Equal(t, expSum.CribStats.Median(), actSum.CribStats.Median())
+				assert.InEpsilon(t, expSum.CribStats.Avg(), actSum.CribStats.Avg(), 0.001)
+				assert.InEpsilon(t, expSum.CribStats.Median(), actSum.CribStats.Median(), 0.001)
 				assert.Equal(t, expSum.CribStats.Max(), actSum.CribStats.Max())
 			}
 

--- a/logic/suggestions/handToss_test.go
+++ b/logic/suggestions/handToss_test.go
@@ -182,7 +182,7 @@ func TestGetAllTosses(t *testing.T) {
 				network.ModelCardsFromStrings(tc.hand...),
 			)
 			require.NoError(t, err)
-			for i   := range actSums {
+			for i := range actSums {
 				actSum := actSums[i]
 				expSum := tc.expSummaries[i]
 				assert.Equal(t, expSum.Kept, actSum.Kept)

--- a/logic/suggestions/handToss_test.go
+++ b/logic/suggestions/handToss_test.go
@@ -182,7 +182,7 @@ func TestGetAllTosses(t *testing.T) {
 				network.ModelCardsFromStrings(tc.hand...),
 			)
 			require.NoError(t, err)
-			for i, := range actSums {
+			for i   := range actSums {
 				actSum := actSums[i]
 				expSum := tc.expSummaries[i]
 				assert.Equal(t, expSum.Kept, actSum.Kept)

--- a/logic/suggestions/handToss_test.go
+++ b/logic/suggestions/handToss_test.go
@@ -9,67 +9,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ model.TossStats = (*testingTossStats)(nil)
-
-type testingTossStats struct {
-	min    int
-	avg    float64
-	median float64
-	max    int
-}
-
-func (ts *testingTossStats) Min() int {
-	return ts.min
-}
-
-func (ts *testingTossStats) Median() float64 {
-	return ts.median
-}
-
-func (ts *testingTossStats) Avg() float64 {
-	return ts.avg
-}
-
-func (ts *testingTossStats) Max() int {
-	return ts.max
-}
-
 func TestGetStatsForHand(t *testing.T) {
 	tests := []struct {
 		desc         string
 		hand         []string
 		tossed       []string
-		expHandStats *testingTossStats
-		expCribStats *testingTossStats
+		expHandStats *model.TestingTossStats
+		expCribStats *model.TestingTossStats
 	}{{
 		desc:   `low pointer`,
 		hand:   []string{`AH`, `QH`, `JC`, `9D`},
 		tossed: []string{`10S`, `KS`},
-		expHandStats: &testingTossStats{
-			avg:    2.282608695652174,
-			median: 2,
-			max:    7,
-		},
-		expCribStats: &testingTossStats{
-			avg:    3.527975406236276,
-			median: 2,
-			max:    20,
-		},
+		expHandStats: model.NewTestingTossStats(
+			0,
+			2.282608695652174,
+			2,
+			7,
+		),
+		expCribStats: model.NewTestingTossStats(
+			0,
+			3.527975406236276,
+			2,
+			20,
+		),
 	}, {
 		desc:   `max pointer`,
 		hand:   []string{`5h`, `jd`, `5C`, `5s`},
 		tossed: []string{`4d`, `6d`},
-		expHandStats: &testingTossStats{
-			min:    14,
-			avg:    16.608695652173914,
-			median: 14,
-			max:    29,
-		},
-		expCribStats: &testingTossStats{
-			avg:    3.9596179183135707,
-			median: 4,
-			max:    24,
-		},
+		expHandStats: model.NewTestingTossStats(
+			14,
+			16.608695652173914,
+			14,
+			29,
+		),
+		expCribStats: model.NewTestingTossStats(
+			0,
+			3.9596179183135707,
+			4,
+			24,
+		),
 	}}
 
 	for _, tc := range tests {
@@ -102,76 +80,78 @@ func TestGetAllTosses(t *testing.T) {
 		expSummaries: []model.TossSummary{{
 			Kept:   network.ModelCardsFromStrings(`5h`, `jd`, `5C`, `5s`),
 			Tossed: network.ModelCardsFromStrings(`6d`),
-			HandStats: &testingTossStats{
-				min:    14,
-				avg:    16.574468085106382,
-				median: 14,
-				max:    29,
-			},
-			CribStats: &testingTossStats{
-				avg:    4.228551004961735,
-				median: 4,
-				max:    24,
-			},
+			HandStats: model.NewTestingTossStats(
+				14,
+				16.574468085106382,
+				14,
+				29,
+			),
+			CribStats: model.NewTestingTossStats(
+				0,
+				4.228551004961735,
+				4,
+				24,
+			),
 		}, {
 			Kept:   network.ModelCardsFromStrings(`5h`, `jd`, `5C`, `6d`),
 			Tossed: network.ModelCardsFromStrings(`5s`),
-			HandStats: &testingTossStats{
-				min:    6,
-				avg:    9.46808510638298,
-				median: 10,
-				max:    17,
-			},
-			CribStats: &testingTossStats{
-				min:    2,
-				avg:    6.144672441342191,
-				median: 6,
-				max:    24,
-			},
+			HandStats: model.NewTestingTossStats(
+				6,
+				9.46808510638298,
+				10,
+				17,
+			),
+			CribStats: model.NewTestingTossStats(
+				2,
+				6.144672441342191,
+				6,
+				24,
+			),
 		}, {
 			Kept:   network.ModelCardsFromStrings(`5h`, `jd`, `5s`, `6d`),
 			Tossed: network.ModelCardsFromStrings(`5c`),
-			HandStats: &testingTossStats{
-				min:    6,
-				avg:    9.46808510638298,
-				median: 10,
-				max:    17,
-			},
-			CribStats: &testingTossStats{
-				min:    2,
-				avg:    6.144672441342191,
-				median: 6,
-				max:    24,
-			},
+			HandStats: model.NewTestingTossStats(
+				6,
+				9.46808510638298,
+				10,
+				17,
+			),
+			CribStats: model.NewTestingTossStats(
+				2,
+				6.144672441342191,
+				6,
+				24,
+			),
 		}, {
 			Kept:   network.ModelCardsFromStrings(`5h`, `5C`, `5s`, `6d`),
 			Tossed: network.ModelCardsFromStrings(`jd`),
-			HandStats: &testingTossStats{
-				min:    8,
-				avg:    12.51063829787234,
-				median: 14,
-				max:    23,
-			},
-			CribStats: &testingTossStats{
-				avg:    4.066820844896701,
-				median: 4,
-				max:    21,
-			},
+			HandStats: model.NewTestingTossStats(
+				8,
+				12.51063829787234,
+				14,
+				23,
+			),
+			CribStats: model.NewTestingTossStats(
+				0,
+				4.066820844896701,
+				4,
+				21,
+			),
 		}, {
 			Kept:   network.ModelCardsFromStrings(`jd`, `5C`, `5s`, `6d`),
 			Tossed: network.ModelCardsFromStrings(`5h`),
-			HandStats: &testingTossStats{
-				min:    6,
-				avg:    9.46808510638298,
-				median: 10,
-				max:    17,
-			},
-			CribStats: &testingTossStats{
-				min:    2,
-				avg:    6.144672441342191,
-				median: 6,
-				max:    24,
-			},
+			HandStats: model.NewTestingTossStats(
+				6,
+				9.46808510638298,
+				10,
+				17,
+			),
+			CribStats: model.NewTestingTossStats(
+				2,
+				6.144672441342191,
+				6,
+				24,
+			),
 		}},
 	}}
 

--- a/logic/suggestions/handToss_test.go
+++ b/logic/suggestions/handToss_test.go
@@ -1,0 +1,201 @@
+package suggestions
+
+import (
+	"testing"
+
+	"github.com/joshprzybyszewski/cribbage/model"
+	"github.com/joshprzybyszewski/cribbage/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ model.TossStats = (*testingTossStats)(nil)
+
+type testingTossStats struct {
+	min    int
+	avg    float64
+	median float64
+	max    int
+}
+
+func (ts *testingTossStats) Min() int {
+	return ts.min
+}
+
+func (ts *testingTossStats) Median() float64 {
+	return ts.median
+}
+
+func (ts *testingTossStats) Avg() float64 {
+	return ts.avg
+}
+
+func (ts *testingTossStats) Max() int {
+	return ts.max
+}
+
+func TestGetStatsForHand(t *testing.T) {
+	tests := []struct {
+		desc         string
+		hand         []string
+		tossed       []string
+		expHandStats *testingTossStats
+		expCribStats *testingTossStats
+	}{{
+		desc:   `low pointer`,
+		hand:   []string{`AH`, `QH`, `JC`, `9D`},
+		tossed: []string{`10S`, `KS`},
+		expHandStats: &testingTossStats{
+			avg:    2.282608695652174,
+			median: 2,
+			max:    7,
+		},
+		expCribStats: &testingTossStats{
+			avg:    3.527975406236276,
+			median: 2,
+			max:    20,
+		},
+	}, {
+		desc:   `max pointer`,
+		hand:   []string{`5h`, `jd`, `5C`, `5s`},
+		tossed: []string{`4d`, `6d`},
+		expHandStats: &testingTossStats{
+			min:    14,
+			avg:    16.608695652173914,
+			median: 14,
+			max:    29,
+		},
+		expCribStats: &testingTossStats{
+			avg:    3.9596179183135707,
+			median: 4,
+			max:    24,
+		},
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			actHand, actCrib := getStatsForHand(
+				network.ModelCardsFromStrings(tc.hand...),
+				network.ModelCardsFromStrings(tc.tossed...),
+			)
+			assert.Equal(t, tc.expHandStats.Min(), actHand.Min())
+			assert.Equal(t, tc.expHandStats.Avg(), actHand.Avg())
+			assert.Equal(t, tc.expHandStats.Median(), actHand.Median())
+			assert.Equal(t, tc.expHandStats.Max(), actHand.Max())
+			assert.Equal(t, tc.expCribStats.Min(), actCrib.Min())
+			assert.Equal(t, tc.expCribStats.Avg(), actCrib.Avg())
+			assert.Equal(t, tc.expCribStats.Median(), actCrib.Median())
+			assert.Equal(t, tc.expCribStats.Max(), actCrib.Max())
+		})
+	}
+}
+
+func TestGetAllTosses(t *testing.T) {
+	tests := []struct {
+		desc         string
+		hand         []string
+		expSummaries []model.TossSummary
+	}{{
+		desc: `max pointer`,
+		hand: []string{`5h`, `jd`, `5C`, `5s`, `6d`},
+		expSummaries: []model.TossSummary{{
+			Kept:   network.ModelCardsFromStrings(`5h`, `jd`, `5C`, `5s`),
+			Tossed: network.ModelCardsFromStrings(`6d`),
+			HandStats: &testingTossStats{
+				min:    14,
+				avg:    16.574468085106382,
+				median: 14,
+				max:    29,
+			},
+			CribStats: &testingTossStats{
+				avg:    4.228551004961735,
+				median: 4,
+				max:    24,
+			},
+		}, {
+			Kept:   network.ModelCardsFromStrings(`5h`, `jd`, `5C`, `6d`),
+			Tossed: network.ModelCardsFromStrings(`5s`),
+			HandStats: &testingTossStats{
+				min:    6,
+				avg:    9.46808510638298,
+				median: 10,
+				max:    17,
+			},
+			CribStats: &testingTossStats{
+				min:    2,
+				avg:    6.144672441342191,
+				median: 6,
+				max:    24,
+			},
+		}, {
+			Kept:   network.ModelCardsFromStrings(`5h`, `jd`, `5s`, `6d`),
+			Tossed: network.ModelCardsFromStrings(`5c`),
+			HandStats: &testingTossStats{
+				min:    6,
+				avg:    9.46808510638298,
+				median: 10,
+				max:    17,
+			},
+			CribStats: &testingTossStats{
+				min:    2,
+				avg:    6.144672441342191,
+				median: 6,
+				max:    24,
+			},
+		}, {
+			Kept:   network.ModelCardsFromStrings(`5h`, `5C`, `5s`, `6d`),
+			Tossed: network.ModelCardsFromStrings(`jd`),
+			HandStats: &testingTossStats{
+				min:    8,
+				avg:    12.51063829787234,
+				median: 14,
+				max:    23,
+			},
+			CribStats: &testingTossStats{
+				avg:    4.066820844896701,
+				median: 4,
+				max:    21,
+			},
+		}, {
+			Kept:   network.ModelCardsFromStrings(`jd`, `5C`, `5s`, `6d`),
+			Tossed: network.ModelCardsFromStrings(`5h`),
+			HandStats: &testingTossStats{
+				min:    6,
+				avg:    9.46808510638298,
+				median: 10,
+				max:    17,
+			},
+			CribStats: &testingTossStats{
+				min:    2,
+				avg:    6.144672441342191,
+				median: 6,
+				max:    24,
+			},
+		}},
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			actSums, err := GetAllTosses(
+				network.ModelCardsFromStrings(tc.hand...),
+			)
+			require.NoError(t, err)
+			for i, actSum := range actSums {
+				expSum := tc.expSummaries[i]
+				assert.Equal(t, expSum.Kept, actSum.Kept)
+				assert.Equal(t, expSum.Tossed, actSum.Tossed)
+				assert.Equal(t, expSum.HandStats.Min(), actSum.HandStats.Min())
+				assert.Equal(t, expSum.HandStats.Avg(), actSum.HandStats.Avg())
+				assert.Equal(t, expSum.HandStats.Median(), actSum.HandStats.Median())
+				assert.Equal(t, expSum.HandStats.Max(), actSum.HandStats.Max())
+				assert.Equal(t, expSum.CribStats.Min(), actSum.CribStats.Min())
+				assert.Equal(t, expSum.CribStats.Avg(), actSum.CribStats.Avg())
+				assert.Equal(t, expSum.CribStats.Median(), actSum.CribStats.Median())
+				assert.Equal(t, expSum.CribStats.Max(), actSum.CribStats.Max())
+			}
+
+		})
+	}
+}

--- a/logic/suggestions/tossStats.go
+++ b/logic/suggestions/tossStats.go
@@ -1,0 +1,70 @@
+package suggestions
+
+import (
+	"sort"
+
+	"github.com/joshprzybyszewski/cribbage/model"
+)
+
+var _ model.TossStats = (*tossStats)(nil)
+
+type tossStats struct {
+	allPts []int
+
+	min    int
+	avg    float64
+	median float64
+	max    int
+}
+
+func (ts *tossStats) add(pts int) {
+	ts.allPts = append(ts.allPts, pts)
+}
+
+func (ts *tossStats) calculate() {
+	if len(ts.allPts) == 0 {
+		return
+	}
+
+	sort.Ints(ts.allPts) // sort the numbers
+
+	ts.min = ts.allPts[0]
+	ts.max = ts.allPts[len(ts.allPts)-1]
+
+	ts.avg = ts.getAvg()
+	ts.median = ts.getMedian()
+}
+
+func (ts *tossStats) getAvg() float64 {
+	sum := 0
+	for _, pt := range ts.allPts {
+		sum += pt
+	}
+	return float64(sum) / float64(len(ts.allPts))
+}
+
+func (ts *tossStats) getMedian() float64 {
+	midIndex := len(ts.allPts) / 2
+
+	if len(ts.allPts)%2 == 1 {
+		return float64(ts.allPts[midIndex])
+	}
+
+	return float64(ts.allPts[midIndex-1]+ts.allPts[midIndex]) / 2
+}
+
+func (ts *tossStats) Min() int {
+	return ts.min
+}
+
+func (ts *tossStats) Median() float64 {
+	return ts.median
+}
+
+func (ts *tossStats) Avg() float64 {
+	return ts.avg
+}
+
+func (ts *tossStats) Max() int {
+	return ts.max
+}

--- a/logic/suggestions/tossStats.go
+++ b/logic/suggestions/tossStats.go
@@ -26,7 +26,7 @@ func (ts *tossStats) calculate() {
 		return
 	}
 
-	sort.Ints(ts.allPts) // sort the numbers
+	sort.Ints(ts.allPts)
 
 	ts.min = ts.allPts[0]
 	ts.max = ts.allPts[len(ts.allPts)-1]

--- a/logic/suggestions/tossStats_test.go
+++ b/logic/suggestions/tossStats_test.go
@@ -1,0 +1,32 @@
+package suggestions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTossStatsCalculate(t *testing.T) {
+	ts := &tossStats{
+		allPts: []int{
+			1, 1, 1,
+			4, 4, 4,
+			10, 10,
+		},
+	}
+
+	ts.add(10)
+	assert.Len(t, ts.allPts, 9)
+
+	// before calling calculate
+	assert.Zero(t, ts.Min())
+	assert.Zero(t, ts.Median())
+	assert.Zero(t, ts.Avg())
+	assert.Zero(t, ts.Max())
+
+	ts.calculate()
+	assert.Equal(t, 1, ts.Min())
+	assert.Equal(t, float64(4), ts.Median())
+	assert.Equal(t, float64(5), ts.Avg())
+	assert.Equal(t, 10, ts.Max())
+}

--- a/logic/suggestions/tossStats_test.go
+++ b/logic/suggestions/tossStats_test.go
@@ -26,7 +26,7 @@ func TestTossStatsCalculate(t *testing.T) {
 
 	ts.calculate()
 	assert.Equal(t, 1, ts.Min())
-	assert.Equal(t, float64(4), ts.Median())
-	assert.Equal(t, float64(5), ts.Avg())
+	assert.InEpsilon(t, float64(4), ts.Median(), 0.001)
+	assert.InEpsilon(t, float64(5), ts.Avg(), 0.001)
 	assert.Equal(t, 10, ts.Max())
 }

--- a/logic/suggestions/utils.go
+++ b/logic/suggestions/utils.go
@@ -38,38 +38,38 @@ func otherOptions(desired int, exclude map[model.Card]struct{}) [][]model.Card {
 	return options
 }
 
-func chooseNFrom(k int, hand []model.Card) ([][]model.Card, error) {
-	if k < 1 || k > len(hand) {
-		return nil, errors.New(`developer error: invalid k`)
+func chooseNFrom(n int, hand []model.Card) ([][]model.Card, error) {
+	if n < 1 || n > len(hand) {
+		return nil, errors.New(`developer error: invalid n`)
 	}
 	if len(hand) > 6 {
 		return nil, errors.New(`too many cards in hand (maximum 6)`)
 	}
-	if k == 1 {
+	if n == 1 {
 		all := make([][]model.Card, len(hand))
 		for i, e := range hand {
 			all[i] = []model.Card{e}
 		}
 		return all, nil
 	}
-	if k == len(hand) {
+	if n == len(hand) {
 		cpy := make([]model.Card, len(hand))
 		copy(cpy, hand)
 		return [][]model.Card{cpy}, nil
 	}
 	// 6 choose 3 = 20, the max number of combos we would ever have
 	all := make([][]model.Card, 0, 20)
-	// for the first n-k cards, recursively find combinations of length k-1 which are
-	// combined with the current card to get combinations of length k
-	for i := 0; i <= len(hand)-k; i++ {
+	// for the first len(hand)-n cards, recursively find combinations of length n-1 which are
+	// combined with the current card to get combinations of length n
+	for i := 0; i <= len(hand)-n; i++ {
 		c := hand[i]
 		others := hand[i+1:]
-		otherSets, err := chooseNFrom(k-1, others)
+		otherSets, err := chooseNFrom(n-1, others)
 		if err != nil {
 			return nil, err
 		}
 		for _, s := range otherSets {
-			set := make([]model.Card, 1, k)
+			set := make([]model.Card, 1, n)
 			set[0] = c
 			set = append(set, s...)
 			all = append(all, set)

--- a/logic/suggestions/utils.go
+++ b/logic/suggestions/utils.go
@@ -1,4 +1,4 @@
-package strategy
+package suggestions
 
 import (
 	"errors"
@@ -6,17 +6,17 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
-func otherOptions(desired int, avoid map[model.Card]struct{}) [][]model.Card {
+func otherOptions(desired int, exclude map[model.Card]struct{}) [][]model.Card {
 	options := [][]model.Card{}
 
 	for o1 := 0; o1 < 52; o1++ {
 		oc1 := model.NewCardFromNumber(o1)
-		if _, ok := avoid[oc1]; ok {
+		if _, ok := exclude[oc1]; ok {
 			continue
 		}
 		for o2 := o1 + 1; o2 < 52; o2++ {
 			oc2 := model.NewCardFromNumber(o2)
-			if _, ok := avoid[oc2]; ok {
+			if _, ok := exclude[oc2]; ok {
 				continue
 			}
 
@@ -27,7 +27,7 @@ func otherOptions(desired int, avoid map[model.Card]struct{}) [][]model.Card {
 
 			for o3 := o2 + 1; o3 < 52; o3++ {
 				oc3 := model.NewCardFromNumber(o3)
-				if _, ok := avoid[oc3]; ok {
+				if _, ok := exclude[oc3]; ok {
 					continue
 				}
 				options = append(options, []model.Card{oc1, oc2, oc3})
@@ -38,7 +38,7 @@ func otherOptions(desired int, avoid map[model.Card]struct{}) [][]model.Card {
 	return options
 }
 
-func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
+func chooseNFrom(k int, hand []model.Card) ([][]model.Card, error) {
 	if k < 1 || k > len(hand) {
 		return nil, errors.New(`developer error: invalid k`)
 	}
@@ -64,7 +64,7 @@ func chooseFrom(k int, hand []model.Card) ([][]model.Card, error) {
 	for i := 0; i <= len(hand)-k; i++ {
 		c := hand[i]
 		others := hand[i+1:]
-		otherSets, err := chooseFrom(k-1, others)
+		otherSets, err := chooseNFrom(k-1, others)
 		if err != nil {
 			return nil, err
 		}

--- a/logic/suggestions/utils_test.go
+++ b/logic/suggestions/utils_test.go
@@ -1,4 +1,4 @@
-package strategy
+package suggestions
 
 import (
 	"errors"
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/joshprzybyszewski/cribbage/model"
+	"github.com/joshprzybyszewski/cribbage/network"
 )
 
 func validateHand(superset, subset []model.Card) bool {
@@ -58,7 +59,7 @@ func generateHand(n int) []model.Card {
 	return hand
 }
 
-func TestChooseFrom(t *testing.T) {
+func TestChooseNFrom(t *testing.T) {
 	tests := []struct {
 		desc   string
 		hand   []model.Card
@@ -112,7 +113,7 @@ func TestChooseFrom(t *testing.T) {
 	}}
 	fCache := make(map[int]int)
 	for _, tc := range tests {
-		all, err := chooseFrom(tc.nCards, tc.hand)
+		all, err := chooseNFrom(tc.nCards, tc.hand)
 		if tc.expErr != `` {
 			assert.EqualError(t, err, tc.expErr)
 		} else {
@@ -126,5 +127,35 @@ func TestChooseFrom(t *testing.T) {
 				assert.True(t, ok)
 			}
 		}
+	}
+}
+
+func TestWithout(t *testing.T) {
+	tests := []struct {
+		desc   string
+		hand   []string
+		remove []string
+		exp    []string
+	}{{
+		desc:   `happy`,
+		hand:   []string{`AH`, `KS`},
+		remove: []string{`KS`},
+		exp:    []string{`AH`},
+	}, {
+		desc:   `6 cards less two`,
+		hand:   []string{`AH`, `KS`, `QH`, `JC`, `10S`, `9D`},
+		remove: []string{`10S`, `KS`},
+		exp:    []string{`AH`, `QH`, `JC`, `9D`},
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			act := without(
+				network.ModelCardsFromStrings(tc.hand...),
+				network.ModelCardsFromStrings(tc.remove...),
+			)
+			assert.Equal(t, network.ModelCardsFromStrings(tc.exp...), act)
+		})
 	}
 }

--- a/logic/suggestions/utils_test.go
+++ b/logic/suggestions/utils_test.go
@@ -99,12 +99,12 @@ func TestChooseNFrom(t *testing.T) {
 		desc:   `5 choose 6`,
 		hand:   generateHand(5),
 		nCards: 6,
-		expErr: `developer error: invalid k`,
+		expErr: `developer error: invalid n`,
 	}, {
 		desc:   `choose zero cards`,
 		hand:   generateHand(5),
 		nCards: 0,
-		expErr: `developer error: invalid k`,
+		expErr: `developer error: invalid n`,
 	}, {
 		desc:   `hand too large`,
 		hand:   generateHand(7),

--- a/model/card_test.go
+++ b/model/card_test.go
@@ -80,6 +80,7 @@ func TestNewCardFromString(t *testing.T) {
 }
 
 func TestNewCardFromStringWithWeirdInput(t *testing.T) {
+	// We don't support emojis
 	testCases := []struct {
 		desc  string
 		input string
@@ -125,7 +126,7 @@ func TestPegValue(t *testing.T) {
 		expValue: 10,
 	}, {
 		desc:     `Queen of Hearts`,
-		input:    `12♥h`,
+		input:    `12h`,
 		expValue: 10,
 	}, {
 		desc:     `King of Diamonds`,

--- a/model/suggestions.go
+++ b/model/suggestions.go
@@ -1,0 +1,16 @@
+package model
+
+type TossSummary struct {
+	Kept   []Card
+	Tossed []Card
+
+	HandStats TossStats
+	CribStats TossStats
+}
+
+type TossStats interface {
+	Min() int
+	Median() float64
+	Avg() float64
+	Max() int
+}

--- a/model/test_utils.go
+++ b/model/test_utils.go
@@ -1,0 +1,37 @@
+// +build !prod
+
+package model
+
+var _ TossStats = (*TestingTossStats)(nil)
+
+type TestingTossStats struct {
+	min    int
+	avg    float64
+	median float64
+	max    int
+}
+
+func NewTestingTossStats(min int, avg, median float64, max int) *TestingTossStats {
+	return &TestingTossStats{
+		min:    min,
+		avg:    avg,
+		median: median,
+		max:    max,
+	}
+}
+
+func (ts *TestingTossStats) Min() int {
+	return ts.min
+}
+
+func (ts *TestingTossStats) Median() float64 {
+	return ts.median
+}
+
+func (ts *TestingTossStats) Avg() float64 {
+	return ts.avg
+}
+
+func (ts *TestingTossStats) Max() int {
+	return ts.max
+}

--- a/network/game_test.go
+++ b/network/game_test.go
@@ -8,14 +8,6 @@ import (
 	"github.com/joshprzybyszewski/cribbage/model"
 )
 
-func modelCardsFromStrings(cs ...string) []model.Card {
-	hand := make([]model.Card, len(cs))
-	for i, c := range cs {
-		hand[i] = model.NewCardFromString(c)
-	}
-	return hand
-}
-
 func cardsFromStrings(cs ...string) []Card {
 	hand := make([]Card, len(cs))
 	for i, c := range cs {
@@ -143,10 +135,10 @@ func TestConvertToGetGameResponse(t *testing.T) {
 			},
 			CurrentDealer: bobID,
 			Hands: map[model.PlayerID][]model.Card{
-				aliceID: modelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
-				bobID:   modelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
+				aliceID: ModelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
+				bobID:   ModelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
 			},
-			Crib:    modelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
+			Crib:    ModelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
 			CutCard: model.NewCardFromString(`5c`),
 			PeggedCards: []model.PeggedCard{{
 				Card:     model.NewCardFromString(`ah`),
@@ -280,10 +272,10 @@ func TestConvertToGetGameResponseForPlayer(t *testing.T) {
 			},
 			CurrentDealer: bobID,
 			Hands: map[model.PlayerID][]model.Card{
-				aliceID: modelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
-				bobID:   modelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
+				aliceID: ModelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
+				bobID:   ModelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
 			},
-			Crib:    modelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
+			Crib:    ModelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
 			CutCard: model.NewCardFromString(`5c`),
 			PeggedCards: []model.PeggedCard{{
 				Card:     model.NewCardFromString(`ah`),
@@ -372,10 +364,10 @@ func TestConvertToGetGameResponseForPlayer(t *testing.T) {
 			},
 			CurrentDealer: bobID,
 			Hands: map[model.PlayerID][]model.Card{
-				aliceID: modelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
-				bobID:   modelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
+				aliceID: ModelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
+				bobID:   ModelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
 			},
-			Crib:    modelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
+			Crib:    ModelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
 			CutCard: model.NewCardFromString(`5c`),
 			PeggedCards: []model.PeggedCard{{
 				Card:     model.NewCardFromString(`ah`),
@@ -464,10 +456,10 @@ func TestConvertToGetGameResponseForPlayer(t *testing.T) {
 			},
 			CurrentDealer: bobID,
 			Hands: map[model.PlayerID][]model.Card{
-				aliceID: modelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
-				bobID:   modelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
+				aliceID: ModelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
+				bobID:   ModelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
 			},
-			Crib:    modelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
+			Crib:    ModelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
 			CutCard: model.NewCardFromString(`5c`),
 			PeggedCards: []model.PeggedCard{{
 				Card:     model.NewCardFromString(`ah`),
@@ -586,10 +578,10 @@ func TestConvertToGetGameResponseForPlayer(t *testing.T) {
 			},
 			CurrentDealer: bobID,
 			Hands: map[model.PlayerID][]model.Card{
-				aliceID: modelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
-				bobID:   modelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
+				aliceID: ModelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
+				bobID:   ModelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
 			},
-			Crib:    modelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
+			Crib:    ModelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
 			CutCard: model.NewCardFromString(`5c`),
 			PeggedCards: []model.PeggedCard{{
 				Card:     model.NewCardFromString(`ah`),
@@ -707,10 +699,10 @@ func TestConvertToGetGameResponseForPlayer(t *testing.T) {
 			},
 			CurrentDealer: bobID,
 			Hands: map[model.PlayerID][]model.Card{
-				aliceID: modelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
-				bobID:   modelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
+				aliceID: ModelCardsFromStrings(`ah`, `2h`, `3h`, `4h`),
+				bobID:   ModelCardsFromStrings(`as`, `2s`, `3s`, `4s`),
 			},
-			Crib:    modelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
+			Crib:    ModelCardsFromStrings(`5h`, `6h`, `5s`, `6s`),
 			CutCard: model.NewCardFromString(`5c`),
 		},
 		expResp: GetGameResponse{},

--- a/network/suggest.go
+++ b/network/suggest.go
@@ -17,17 +17,18 @@ type GetSuggestHandResponse struct {
 }
 
 func ConvertToGetSuggestHandResponse(
-	sums []model.TossSummary,
+	summaries []model.TossSummary,
 ) []GetSuggestHandResponse {
 	var resp []GetSuggestHandResponse
-	for _, sum := range sums {
-		hand := make([]string, len(sum.Kept))
-		for i, c := range sum.Kept {
+	for i := range summaries {
+		summ := summaries[i]
+		hand := make([]string, len(summ.Kept))
+		for i, c := range summ.Kept {
 			hand[i] = c.String()
 		}
 
-		toss := make([]string, len(sum.Tossed))
-		for i, c := range sum.Tossed {
+		toss := make([]string, len(summ.Tossed))
+		for i, c := range summ.Tossed {
 			toss[i] = c.String()
 		}
 
@@ -35,16 +36,16 @@ func ConvertToGetSuggestHandResponse(
 			Hand: hand,
 			Toss: toss,
 			HandPts: PointStats{
-				Min:    sum.HandStats.Min(),
-				Avg:    sum.HandStats.Avg(),
-				Median: sum.HandStats.Median(),
-				Max:    sum.HandStats.Max(),
+				Min:    summ.HandStats.Min(),
+				Avg:    summ.HandStats.Avg(),
+				Median: summ.HandStats.Median(),
+				Max:    summ.HandStats.Max(),
 			},
 			CribPts: PointStats{
-				Min:    sum.CribStats.Min(),
-				Avg:    sum.CribStats.Avg(),
-				Median: sum.CribStats.Median(),
-				Max:    sum.CribStats.Max(),
+				Min:    summ.CribStats.Min(),
+				Avg:    summ.CribStats.Avg(),
+				Median: summ.CribStats.Median(),
+				Max:    summ.CribStats.Max(),
 			},
 		})
 	}

--- a/network/suggest.go
+++ b/network/suggest.go
@@ -1,0 +1,52 @@
+package network
+
+import "github.com/joshprzybyszewski/cribbage/model"
+
+type PointStats struct {
+	Min    int     `json:"min"`
+	Median float64 `json:"median"`
+	Avg    float64 `json:"avg"`
+	Max    int     `json:"max"`
+}
+
+type GetSuggestHandResponse struct {
+	Hand    []string   `json:"hand"`
+	Toss    []string   `json:"toss"`
+	HandPts PointStats `json:"handPts"`
+	CribPts PointStats `json:"cribPts"`
+}
+
+func ConvertToGetSuggestHandResponse(
+	sums []model.TossSummary,
+) []GetSuggestHandResponse {
+	var resp []GetSuggestHandResponse
+	for _, sum := range sums {
+		hand := make([]string, len(sum.Kept))
+		for i, c := range sum.Kept {
+			hand[i] = c.String()
+		}
+
+		toss := make([]string, len(sum.Tossed))
+		for i, c := range sum.Tossed {
+			toss[i] = c.String()
+		}
+
+		resp = append(resp, GetSuggestHandResponse{
+			Hand: hand,
+			Toss: toss,
+			HandPts: PointStats{
+				Min:    sum.HandStats.Min(),
+				Avg:    sum.HandStats.Avg(),
+				Median: sum.HandStats.Median(),
+				Max:    sum.HandStats.Max(),
+			},
+			CribPts: PointStats{
+				Min:    sum.CribStats.Min(),
+				Avg:    sum.CribStats.Avg(),
+				Median: sum.CribStats.Median(),
+				Max:    sum.CribStats.Max(),
+			},
+		})
+	}
+	return resp
+}

--- a/network/suggest_test.go
+++ b/network/suggest_test.go
@@ -1,0 +1,51 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/joshprzybyszewski/cribbage/model"
+)
+
+func TestConvertToGetSuggestHandResponse(t *testing.T) {
+	testCases := []struct {
+		input     []model.TossSummary
+		expOutput []GetSuggestHandResponse
+	}{{
+		input:     nil,
+		expOutput: nil,
+	}, {
+		input: []model.TossSummary{{
+			Kept:   ModelCardsFromStrings(`AH`, `AD`, `AS`, `AC`),
+			Tossed: ModelCardsFromStrings(`2H`, `2D`),
+			HandStats: model.NewTestingTossStats(
+				0, 1, 2, 3,
+			),
+			CribStats: model.NewTestingTossStats(
+				4, 5, 6, 7,
+			),
+		}},
+		expOutput: []GetSuggestHandResponse{{
+			Hand: []string{`AH`, `AD`, `AS`, `AC`},
+			Toss: []string{`2H`, `2D`},
+			HandPts: PointStats{
+				Min:    0,
+				Avg:    1,
+				Median: 2,
+				Max:    3,
+			},
+			CribPts: PointStats{
+				Min:    4,
+				Avg:    5,
+				Median: 6,
+				Max:    7,
+			},
+		}},
+	}}
+
+	for _, tc := range testCases {
+		act := ConvertToGetSuggestHandResponse(tc.input)
+		assert.Equal(t, tc.expOutput, act)
+	}
+}

--- a/network/test_utils.go
+++ b/network/test_utils.go
@@ -1,0 +1,13 @@
+// +build !prod
+
+package network
+
+import "github.com/joshprzybyszewski/cribbage/model"
+
+func ModelCardsFromStrings(cs ...string) []model.Card {
+	hand := make([]model.Card, len(cs))
+	for i, c := range cs {
+		hand[i] = model.NewCardFromString(c)
+	}
+	return hand
+}

--- a/server/play/utils_test.go
+++ b/server/play/utils_test.go
@@ -10,15 +10,15 @@ import (
 
 func TestPlayersToDealTo(t *testing.T) {
 	alice := model.Player{
-		ID:   model.PlayerID(1),
+		ID:   model.PlayerID(`1`),
 		Name: `alice`,
 	}
 	bob := model.Player{
-		ID:   model.PlayerID(2),
+		ID:   model.PlayerID(`2`),
 		Name: `bob`,
 	}
 	charlie := model.Player{
-		ID:   model.PlayerID(3),
+		ID:   model.PlayerID(`3`),
 		Name: `charlie`,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -408,7 +408,7 @@ func (cs *cribbageServer) ginGetSuggestHand(c *gin.Context) {
 
 func convertToHand(input interface{}) ([]model.Card, error) {
 	inputStr, ok := input.(string)
-	if !ok || len(inputStr) == `` {
+	if !ok || inputStr == `` {
 		return nil, errors.New(`empty dealt hand`)
 	}
 	var cards []model.Card

--- a/server/server.go
+++ b/server/server.go
@@ -408,7 +408,7 @@ func (cs *cribbageServer) ginGetSuggestHand(c *gin.Context) {
 
 func convertToHand(input interface{}) ([]model.Card, error) {
 	inputStr, ok := input.(string)
-	if !ok || len(inputStr) == 0 {
+	if !ok || len(inputStr) == `` {
 		return nil, errors.New(`empty dealt hand`)
 	}
 	var cards []model.Card

--- a/server/server.go
+++ b/server/server.go
@@ -393,13 +393,13 @@ func (cs *cribbageServer) ginGetSuggestHand(c *gin.Context) {
 		return
 	}
 
-	sums, err := suggestions.GetAllTosses(hand)
+	summaries, err := suggestions.GetAllTosses(hand)
 	if err != nil {
 		c.String(http.StatusBadRequest, `Error: %s`, err)
 		return
 	}
 
-	resp := network.ConvertToGetSuggestHandResponse(sums)
+	resp := network.ConvertToGetSuggestHandResponse(summaries)
 	sort.Slice(resp, func(i, j int) bool {
 		return resp[i].HandPts.Avg > resp[j].HandPts.Avg
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -415,7 +415,11 @@ func convertToHand(input interface{}) ([]model.Card, error) {
 
 	cardStrs := strings.Split(inputStr, `,`)
 	for _, cs := range cardStrs {
-		cards = append(cards, model.NewCardFromString(cs))
+		c, err := model.NewCardFromExternalString(cs)
+		if err != nil {
+			return nil, err
+		}
+		cards = append(cards, c)
 	}
 
 	return cards, nil

--- a/server/server.go
+++ b/server/server.go
@@ -2,15 +2,19 @@ package server
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/contrib/static"
 	"github.com/gin-gonic/gin"
 
 	"github.com/joshprzybyszewski/cribbage/jsonutils"
+	"github.com/joshprzybyszewski/cribbage/logic/suggestions"
 	"github.com/joshprzybyszewski/cribbage/model"
 	"github.com/joshprzybyszewski/cribbage/network"
 	"github.com/joshprzybyszewski/cribbage/server/interaction"
@@ -53,6 +57,12 @@ func (cs *cribbageServer) NewRouter() http.Handler {
 	}
 
 	router.POST(`/action`, cs.ginPostAction)
+
+	// Simple group: suggest
+	suggest := router.Group(`/suggest`)
+	{
+		suggest.GET(`/hand`, cs.ginGetSuggestHand)
+	}
 
 	return router
 }
@@ -372,4 +382,41 @@ func (cs *cribbageServer) ginPostAction(c *gin.Context) {
 	}
 
 	c.String(http.StatusOK, `action handled`)
+}
+
+// GET /suggest/hand?dealt=<cards>
+func (cs *cribbageServer) ginGetSuggestHand(c *gin.Context) {
+
+	hand, err := convertToHand(c.Query(`dealt`))
+	if err != nil {
+		c.String(http.StatusBadRequest, `Error: %s`, err)
+		return
+	}
+
+	sums, err := suggestions.GetAllTosses(hand)
+	if err != nil {
+		c.String(http.StatusBadRequest, `Error: %s`, err)
+		return
+	}
+
+	resp := network.ConvertToGetSuggestHandResponse(sums)
+	sort.Slice(resp, func(i, j int) bool {
+		return resp[i].HandPts.Avg > resp[j].HandPts.Avg
+	})
+	c.JSON(http.StatusOK, resp)
+}
+
+func convertToHand(input interface{}) ([]model.Card, error) {
+	inputStr, ok := input.(string)
+	if !ok || len(inputStr) == 0 {
+		return nil, errors.New(`empty dealt hand`)
+	}
+	var cards []model.Card
+
+	cardStrs := strings.Split(inputStr, `,`)
+	for _, cs := range cardStrs {
+		cards = append(cards, model.NewCardFromString(cs))
+	}
+
+	return cards, nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -569,6 +569,31 @@ func TestGinGetSuggestHand(t *testing.T) {
 		expCode: http.StatusBadRequest,
 		expErr:  `Error: empty dealt hand`,
 	}, {
+		msg:     `too few cards`,
+		url:     `/suggest/hand?dealt=AH,2H,3H`,
+		expCode: http.StatusBadRequest,
+		expErr:  `Error: hand size must be either 5 or 6`,
+	}, {
+		msg:     `too many cards`,
+		url:     `/suggest/hand?dealt=AH,2H,3H,4H,5H,6H,7H`,
+		expCode: http.StatusBadRequest,
+		expErr:  `Error: hand size must be either 5 or 6`,
+	}, {
+		msg:     `uses duplicate cards`,
+		url:     `/suggest/hand?dealt=AH,AH,2H,3H,4H,5H`,
+		expCode: http.StatusBadRequest,
+		expErr:  `Error: hand contains duplicates`,
+	}, {
+		msg:     `has invalid card`,
+		url:     `/suggest/hand?dealt=AH,15H,2H,3H,4H,5H`,
+		expCode: http.StatusBadRequest,
+		expErr:  `Error: invalid card value`,
+	}, {
+		msg:     `has another invalid card`,
+		url:     `/suggest/hand?dealt=AH,123H,2H,3H,4H,5H`,
+		expCode: http.StatusBadRequest,
+		expErr:  `Error: unknown card`,
+	}, {
 		msg:     `good request`,
 		url:     `/suggest/hand?dealt=JH,KH,QH,9H,10H`,
 		expCode: http.StatusOK,


### PR DESCRIPTION
## What broke / What you're adding
I'd like to have the server logic for suggesting what to toss into the crib so that we can use it on the client (which should be https://github.com/joshprzybyszewski/cribbage/pull/89). Putting the server logic in first will compartmentalize the changes and allow for iteration on UI.

## How you did it
Take the "calculated NPC" logic and consolidate it. Then provide an exported func to access it in a consumable way. Then hook up a rest endpoint that will return the list of results.

## How to test it and how to try to break it
You can hit the endpoint with something like this: `curl localhost:8080/suggest/hand?dealt=5h,5c,5d,js,6s,6h`