### PR TITLE
Use docker-compose to set up the app locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,7 @@ dockerrunlocal: ## Runs the latest tag of the built docker image locally on port
 .PHONY: wasm
 wasm: ## Builds the wasm output for the gowasm client
 	GOOS=js GOARCH=wasm go build -tags prod -o assets/wasm/wa_output.wasm github.com/joshprzybyszewski/cribbage/wasm
+
+.PHONY: localstack
+localstack: ## Runs the app as a local stack in docker-compose
+	docker-compose up -d cribbage-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,3 @@ services:
       CRIBBAGE_MYSQL_CREATE_ERROR_IS_OK: "true"
     ports:
       - "18080:8080"
-  # cribbage:
-  #   depends_on:
-  #     - cribbageServer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  cribbage:
+    build: .
+    env:
+      deploy: docker
+    ports:
+      - "8081:8081"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,14 @@
 version: "3.9"
 services:
+  dynamodb-local:
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    image: "amazon/dynamodb-local:latest"
+    container_name: dynamodb-local
+    ports:
+      - "8000:8000"
+    volumes:
+      - "./docker/dynamodb:/home/dynamodblocal/data"
+    working_dir: /home/dynamodblocal
   cribbage:
     build: .
     env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.8"
 services:
   dynamodb-local:
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
@@ -9,7 +9,21 @@ services:
     volumes:
       - "./docker/dynamodb:/home/dynamodblocal/data"
     working_dir: /home/dynamodblocal
+  dynamoInit:
+    depends_on:
+      - dynamodb-local
+    image: banst/awscli
+    container_name: dynamoInit
+    ports:
+     - "8123:8123"
+    environment:
+      AWS_ACCESS_KEY_ID: 'DUMMYIDEXAMPLE'
+      AWS_SECRET_ACCESS_KEY: 'DUMMYEXAMPLEKEY'
+    command:
+      dynamodb describe-limits --endpoint-url http://dynamodb-local:8000 --region us-west-2
   cribbage:
+    depends_on:
+      - dynamoInit
     build: .
     env:
       deploy: docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       timeout: 20s
       retries: 10
   cribbage-server:
-    build: .
+    image: joshprzybyszewski/cribbage:latest
     depends_on:
       dynamoInit:
         condition: service_started
@@ -43,8 +43,8 @@ services:
       CRIBBAGE_DSN_PASSWORD: flyyoufools
       CRIBBAGE_DSN_PARAMS: "parseTime=true&timeout=90s&writeTimeout=90s&readTimeout=90s&tls=skip-verify&maxAllowedPacket=1000000000&rejectReadOnly=true"
       CRIBBAGE_restPort: 8088
-      # TODO create the tables another way?
-      # CRIBBAGE_MYSQL_CREATE_TABLES: "true"
+      CRIBBAGE_MYSQL_CREATE_TABLES: "true"
+      CRIBBAGE_MYSQL_CREATE_ERROR_IS_OK: "true"
     ports:
       - "18080:8080"
   # cribbage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,14 @@
-version: "3.8"
+version: "3.9"
 services:
   dynamodb-local:
-    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
-    image: "amazon/dynamodb-local:latest"
-    container_name: dynamodb-local
+    image: amazon/dynamodb-local:latest
     ports:
-      - "8000:8000"
-    volumes:
-      - "./docker/dynamodb:/home/dynamodblocal/data"
-    working_dir: /home/dynamodblocal
+      - "20000:20000"
+    command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
   dynamoInit:
     depends_on:
       - dynamodb-local
     image: banst/awscli
-    container_name: dynamoInit
     ports:
      - "8123:8123"
     environment:
@@ -21,11 +16,14 @@ services:
       AWS_SECRET_ACCESS_KEY: 'DUMMYEXAMPLEKEY'
     command:
       dynamodb describe-limits --endpoint-url http://dynamodb-local:8000 --region us-west-2
-  cribbage:
+  cribbageServer:
+    image: cribbage
     depends_on:
       - dynamoInit
-    build: .
-    env:
+    environment:
       deploy: docker
     ports:
-      - "8081:8081"
+      - "8080:8080"
+  # cribbage:
+  #   depends_on:
+  #     - cribbageServer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,28 +14,39 @@ services:
       AWS_SECRET_ACCESS_KEY: 'DUMMYEXAMPLEKEY'
     command:
       dynamodb describe-limits --endpoint-url http://dynamodb-local:8000 --region us-west-2
-  cribbageServer:
-    image: cribbage
+  mysql-database:
+    image: mysql:8
+    restart: always
+    ports:
+      - "13306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: balrog
+      MYSQL_USER: gandalf
+      MYSQL_PASSWORD: flyyoufools
+      MYSQL_DATABASE: cribbage
+    command: ['mysqld', '--skip-character-set-client-handshake', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_0900_as_cs']
+    healthcheck:
+      test: "mysql -P13306 -ugandalf -pflyyoufools  -Dcribbage -e 'SHOW TABLES;'"
+      timeout: 20s
+      retries: 10
+  cribbage-server:
+    build: .
     depends_on:
-      - dynamoInit
-      - mysql
+      dynamoInit:
+        condition: service_started
+      mysql-database:
+        condition: service_healthy
     environment:
       deploy: dockercompose
-      CRIBBAGE_DSN_HOST: mysql
-      CRIBBAGE_DSN_USER: root
-      CRIBBAGE_DSN_PASSWORD: letmein
+      CRIBBAGE_DSN_HOST: mysql-database
+      CRIBBAGE_DSN_USER: gandalf
+      CRIBBAGE_DSN_PASSWORD: flyyoufools
       CRIBBAGE_DSN_PARAMS: "parseTime=true&timeout=90s&writeTimeout=90s&readTimeout=90s&tls=skip-verify&maxAllowedPacket=1000000000&rejectReadOnly=true"
       CRIBBAGE_restPort: 8088
-      CRIBBAGE_MYSQL_CREATE_TABLES: "true"
+      # TODO create the tables another way?
+      # CRIBBAGE_MYSQL_CREATE_TABLES: "true"
     ports:
-      - "18080:8088"
-  mysql:
-    image: mysql:5.7
-    restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: letmein
-      MYSQL_DATABASE: cribbage
-    command: ['mysqld', '--skip-character-set-client-handshake', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
+      - "18080:8080"
   # cribbage:
   #   depends_on:
   #     - cribbageServer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,12 @@ services:
   dynamodb-local:
     image: amazon/dynamodb-local:latest
     ports:
-      - "20000:20000"
+      - "18079:8000"
     command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
   dynamoInit:
     depends_on:
       - dynamodb-local
     image: banst/awscli
-    ports:
-     - "8123:8123"
     environment:
       AWS_ACCESS_KEY_ID: 'DUMMYIDEXAMPLE'
       AWS_SECRET_ACCESS_KEY: 'DUMMYEXAMPLEKEY'
@@ -20,10 +18,24 @@ services:
     image: cribbage
     depends_on:
       - dynamoInit
+      - mysql
     environment:
-      deploy: docker
+      deploy: dockercompose
+      CRIBBAGE_DSN_HOST: mysql
+      CRIBBAGE_DSN_USER: root
+      CRIBBAGE_DSN_PASSWORD: letmein
+      CRIBBAGE_DSN_PARAMS: "parseTime=true&timeout=90s&writeTimeout=90s&readTimeout=90s&tls=skip-verify&maxAllowedPacket=1000000000&rejectReadOnly=true"
+      CRIBBAGE_restPort: 8088
+      CRIBBAGE_MYSQL_CREATE_TABLES: "true"
     ports:
-      - "8080:8080"
+      - "18080:8088"
+  mysql:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: letmein
+      MYSQL_DATABASE: cribbage
+    command: ['mysqld', '--skip-character-set-client-handshake', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
   # cribbage:
   #   depends_on:
   #     - cribbageServer

--- a/server/persistence/mysql/mysql.go
+++ b/server/persistence/mysql/mysql.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 
 	_ "github.com/go-sql-driver/mysql" // nolint:golint
 	"github.com/joshprzybyszewski/cribbage/server/persistence"
@@ -43,6 +44,10 @@ func NewFactory(ctx context.Context, config Config) (persistence.DBFactory, erro
 		for _, createStmt := range allCreateStmts {
 			_, err := db.ExecContext(ctx, createStmt)
 			if err != nil {
+				if config.CreateErrorIsOk {
+					log.Printf("error running CREATE: %q = %v", createStmt, err)
+					continue
+				}
 				return nil, err
 			}
 		}
@@ -86,7 +91,8 @@ type Config struct {
 
 	DatabaseName string
 
-	RunCreateStmts bool
+	RunCreateStmts  bool
+	CreateErrorIsOk bool
 }
 
 var _ persistence.DB = (*mysqlWrapper)(nil)

--- a/server/setup.go
+++ b/server/setup.go
@@ -27,8 +27,14 @@ var (
 	dsnParams   = flag.String(`dsn_params`, `parseTime=true`, `The params for the MySQL DB`)
 	mysqlDBName = flag.String(`mysql_db`, `cribbage`, `The name of the Database to connect to in mysql`)
 
-	createTables          = flag.Bool(`mysql_create_tables`, false, `Set to true when you want to create tables on startup.`)
-	createTablesErrorIsOk = flag.Bool(`mysql_create_error_is_ok`, false, `Set to true when you don't care if table creation fails on startup.`)
+	createTables = flag.Bool(
+		`mysql_create_tables`, false,
+		`Set to true when you want to create tables on startup.`,
+	)
+	createTablesErrorIsOk = flag.Bool(
+		`mysql_create_error_is_ok`, false,
+		`Set to true when you don't care if table creation fails on startup.`,
+	)
 )
 
 // Setup connects to a database and starts serving requests

--- a/server/setup.go
+++ b/server/setup.go
@@ -27,7 +27,8 @@ var (
 	dsnParams   = flag.String(`dsn_params`, `parseTime=true`, `The params for the MySQL DB`)
 	mysqlDBName = flag.String(`mysql_db`, `cribbage`, `The name of the Database to connect to in mysql`)
 
-	createTables = flag.Bool(`mysql_create_tables`, false, `Set to true when you want to create tables on startup.`)
+	createTables          = flag.Bool(`mysql_create_tables`, false, `Set to true when you want to create tables on startup.`)
+	createTablesErrorIsOk = flag.Bool(`mysql_create_error_is_ok`, false, `Set to true when you don't care if table creation fails on startup.`)
 )
 
 // Setup connects to a database and starts serving requests
@@ -63,13 +64,14 @@ func getDBFactory(ctx context.Context, cfg factoryConfig) (persistence.DBFactory
 		return mongodb.NewFactory(*dbURI)
 	case `mysql`:
 		cfg := mysql.Config{
-			DSNUser:        *dsnUser,
-			DSNPassword:    *dsnPassword,
-			DSNHost:        *dsnHost,
-			DSNPort:        *dsnPort,
-			DatabaseName:   *mysqlDBName,
-			DSNParams:      *dsnParams,
-			RunCreateStmts: cfg.canRunCreateStmts && *createTables,
+			DSNUser:         *dsnUser,
+			DSNPassword:     *dsnPassword,
+			DSNHost:         *dsnHost,
+			DSNPort:         *dsnPort,
+			DatabaseName:    *mysqlDBName,
+			DSNParams:       *dsnParams,
+			RunCreateStmts:  cfg.canRunCreateStmts && *createTables,
+			CreateErrorIsOk: cfg.canRunCreateStmts && *createTablesErrorIsOk,
 		}
 		log.Println("Creating mysql factory")
 		log.Printf("  len(User): %d\n", len(cfg.DSNUser))
@@ -78,6 +80,8 @@ func getDBFactory(ctx context.Context, cfg factoryConfig) (persistence.DBFactory
 		log.Printf("  Port: %d\n", cfg.DSNPort)
 		log.Printf("  DatabaseName: %s\n", cfg.DatabaseName)
 		log.Printf("  DSNParams: %s\n", cfg.DSNParams)
+		log.Printf("  RunCreateStmts: %v\n", cfg.RunCreateStmts)
+		log.Printf("  CreateErrorIsOk: %v\n", cfg.CreateErrorIsOk)
 		return mysql.NewFactory(ctx, cfg)
 	case `memory`:
 		log.Println("Creating in-memory factory")


### PR DESCRIPTION
## What broke / What you're adding
I want to add dynamoDB as a persistence option. The first step is to be able to test locally. What seemed like the easiest thing to do is to use docker-compose.

## How you did it
Let's add a docker-compose that runs the app locally. This will also follow some of the internet's instructions for setting up dynamoDB.

## How to test it and how to try to break it
run `docker-compose up cribbage-server` and go to `localhost:18080` and be able to play a game!