### PR TITLE
Fix json game marshalling

### DIFF
--- a/jsonutils/gameUnmarshaller.go
+++ b/jsonutils/gameUnmarshaller.go
@@ -31,5 +31,17 @@ func UnmarshalGame(b []byte) (model.Game, error) {
 		game.Actions[i] = pa
 	}
 
+	if game.Hands == nil {
+		game.Hands = make(map[model.PlayerID][]model.Card, len(game.Players))
+	}
+
+	if game.BlockingPlayers == nil {
+		game.BlockingPlayers = make(map[model.PlayerID]model.Blocker, len(game.Players))
+	}
+
+	if game.PlayerColors == nil {
+		game.PlayerColors = make(map[model.PlayerID]model.PlayerColor, len(game.Players))
+	}
+
 	return game, nil
 }

--- a/jsonutils/gameUnmarshaller_test.go
+++ b/jsonutils/gameUnmarshaller_test.go
@@ -101,6 +101,20 @@ func checkMarshalUnmarshal(t *testing.T, g model.Game, msg string) {
 
 	actGame, err := UnmarshalGame(b)
 	require.NoError(t, err, msg)
+
+	if gameCopy.PlayerColors == nil {
+		assert.NotNil(t, actGame.PlayerColors)
+		actGame.PlayerColors = nil
+	}
+	if gameCopy.BlockingPlayers == nil {
+		assert.NotNil(t, actGame.BlockingPlayers)
+		actGame.BlockingPlayers = nil
+	}
+	if gameCopy.Hands == nil {
+		assert.NotNil(t, actGame.Hands)
+		actGame.Hands = nil
+	}
+
 	assert.Equal(t, gameCopy, actGame, msg)
 }
 
@@ -108,6 +122,7 @@ func TestGameAtAllStages(t *testing.T) {
 	alice, bob, pAPIs := testutils.EmptyAliceAndBob()
 	g, err := play.CreateGame([]model.Player{alice, bob}, pAPIs)
 	require.NoError(t, err)
+	checkMarshalUnmarshal(t, g, `after creation`)
 
 	require.NoError(t, play.HandleAction(&g, model.PlayerAction{
 		ID:        alice.ID,


### PR DESCRIPTION
## What broke / What you're adding
dynamo exposed an issue in the game unmarshalling. The resulting `Hands` field is empty right after creation, and that panics when we try to deal out cards.

## How you did it
write a unit test to verify that. then simply check for the nil fields and instantiate them to empty.

## How to test it and how to try to break it
CI was broken. now CI is happy.