### PR TITLE
clean up persistence tests

### DIFF
--- a/jsonutils/playerActionUnmarshaller_test.go
+++ b/jsonutils/playerActionUnmarshaller_test.go
@@ -24,7 +24,6 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.DealAction{
 				NumShuffles: 543,
 			},
-			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `crib`,
@@ -38,7 +37,6 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 					model.NewCardFromString(`5d`),
 				},
 			},
-			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `cut`,
@@ -59,7 +57,6 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.PegAction{
 				Card: model.NewCardFromString(`jh`),
 			},
-			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `peg saygo`,
@@ -70,7 +67,6 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.PegAction{
 				SayGo: true,
 			},
-			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `count hand`,
@@ -81,7 +77,6 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.CountHandAction{
 				Pts: 29,
 			},
-			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `count crib`,
@@ -92,11 +87,11 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.CountCribAction{
 				Pts: 12,
 			},
-			TimeStamp: time.Now(),
 		},
 	}}
 
 	for _, tc := range testCases {
+		tc.pa.SetTimeStamp(time.Now())
 		paCopy := tc.pa
 		b, err := json.Marshal(tc.pa)
 		require.NoError(t, err, tc.msg)

--- a/jsonutils/playerActionUnmarshaller_test.go
+++ b/jsonutils/playerActionUnmarshaller_test.go
@@ -3,6 +3,7 @@ package jsonutils
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,7 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.DealAction{
 				NumShuffles: 543,
 			},
+			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `crib`,
@@ -36,6 +38,7 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 					model.NewCardFromString(`5d`),
 				},
 			},
+			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `cut`,
@@ -56,6 +59,7 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.PegAction{
 				Card: model.NewCardFromString(`jh`),
 			},
+			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `peg saygo`,
@@ -66,6 +70,7 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.PegAction{
 				SayGo: true,
 			},
+			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `count hand`,
@@ -76,6 +81,7 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.CountHandAction{
 				Pts: 29,
 			},
+			TimeStamp: time.Now(),
 		},
 	}, {
 		msg: `count crib`,
@@ -86,6 +92,7 @@ func TestUnmarshalPlayerAction(t *testing.T) {
 			Action: model.CountCribAction{
 				Pts: 12,
 			},
+			TimeStamp: time.Now(),
 		},
 	}}
 

--- a/model/model.go
+++ b/model/model.go
@@ -152,7 +152,24 @@ type PlayerAction struct {
 	ID        PlayerID    `json:"pID" bson:"pID"`
 	Overcomes Blocker     `json:"o" bson:"o"`
 	Action    interface{} `json:"a" bson:"a"`
-	TimeStamp time.Time   `json:"timestamp,omitempty" bson:"timestamp"`
+
+	TimestampStr string `json:"timestamp,omitempty" bson:"-"`
+}
+
+const (
+	playerActionLayoutString = time.RFC3339
+)
+
+func (pa *PlayerAction) SetTimeStamp(ts time.Time) {
+	pa.TimestampStr = ts.Format(playerActionLayoutString)
+}
+
+func (pa *PlayerAction) TimeStamp() time.Time {
+	ts, err := time.Parse(playerActionLayoutString, pa.TimestampStr)
+	if err != nil {
+		ts = time.Time{}
+	}
+	return ts
 }
 
 type DealAction struct {

--- a/model/model.go
+++ b/model/model.go
@@ -164,14 +164,6 @@ func (pa *PlayerAction) SetTimeStamp(ts time.Time) {
 	pa.TimestampStr = ts.Format(playerActionLayoutString)
 }
 
-func (pa *PlayerAction) TimeStamp() time.Time {
-	ts, err := time.Parse(playerActionLayoutString, pa.TimestampStr)
-	if err != nil {
-		ts = time.Time{}
-	}
-	return ts
-}
-
 type DealAction struct {
 	NumShuffles int `json:"ns" bson:"ns"`
 }

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -58,4 +59,13 @@ func TestPhaseStringConversions(t *testing.T) {
 	assert.Equal(t, `unknown`, unknownPhase.String())
 	assert.Equal(t, `unknown`, (Phase)(12).String())
 	assert.Equal(t, unknownPhase, NewPhaseFromString(`other`))
+}
+
+func TestPlayerActionTimeStamp(t *testing.T) {
+	pa := PlayerAction{}
+
+	t0 := time.Now()
+	pa.SetTimeStamp(t0)
+
+	assert.Equal(t, t0.Format(time.RFC3339), pa.TimestampStr)
 }

--- a/network/player.go
+++ b/network/player.go
@@ -49,10 +49,12 @@ type ActiveGamePlayer struct {
 }
 
 type ActiveGame struct {
-	GameID   model.GameID       `json:"gameID"`
-	Players  []ActiveGamePlayer `json:"players"`
-	Created  time.Time          `json:"created"`
-	LastMove time.Time          `json:"lastMove"`
+	GameID  model.GameID       `json:"gameID"`
+	Players []ActiveGamePlayer `json:"players"`
+
+	Created      string `json:"created"`
+	LastMove     string `json:"lastMove"`
+	lastMoveTime time.Time
 }
 
 type GetActiveGamesForPlayerResponse struct {
@@ -84,7 +86,7 @@ func convertToParticipatingGames(
 			res = append(res, getActiveGame(mg))
 		}
 	}
-	sort.Slice(res, func(i, j int) bool { return !res[i].LastMove.Before(res[j].LastMove) })
+	sort.Slice(res, func(i, j int) bool { return !res[i].lastMoveTime.Before(res[j].lastMoveTime) })
 	return res
 }
 
@@ -93,8 +95,9 @@ func getActiveGame(mg model.Game) ActiveGame {
 		GameID: mg.ID,
 	}
 	if len(mg.Actions) > 0 {
-		ag.Created = mg.Actions[0].TimeStamp
-		ag.LastMove = mg.Actions[len(mg.Actions)-1].TimeStamp
+		ag.Created = mg.Actions[0].TimestampStr
+		ag.LastMove = mg.Actions[len(mg.Actions)-1].TimestampStr
+		ag.lastMoveTime = mg.Actions[len(mg.Actions)-1].TimeStamp()
 	}
 	ag.Players = make([]ActiveGamePlayer, len(mg.Players))
 	for i, p := range mg.Players {

--- a/network/player.go
+++ b/network/player.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"sort"
-	"time"
+	"strings"
 
 	"github.com/joshprzybyszewski/cribbage/model"
 )
@@ -52,9 +52,8 @@ type ActiveGame struct {
 	GameID  model.GameID       `json:"gameID"`
 	Players []ActiveGamePlayer `json:"players"`
 
-	Created      string `json:"created"`
-	LastMove     string `json:"lastMove"`
-	lastMoveTime time.Time
+	Created  string `json:"created"`
+	LastMove string `json:"lastMove"`
 }
 
 type GetActiveGamesForPlayerResponse struct {
@@ -86,7 +85,14 @@ func convertToParticipatingGames(
 			res = append(res, getActiveGame(mg))
 		}
 	}
-	sort.Slice(res, func(i, j int) bool { return !res[i].lastMoveTime.Before(res[j].lastMoveTime) })
+	sort.Slice(res, func(i, j int) bool {
+		if res[i].LastMove == `` {
+			return false
+		} else if res[j].LastMove == `` {
+			return true
+		}
+		return strings.Compare(res[i].LastMove, res[j].LastMove) > 0
+	})
 	return res
 }
 
@@ -97,7 +103,6 @@ func getActiveGame(mg model.Game) ActiveGame {
 	if len(mg.Actions) > 0 {
 		ag.Created = mg.Actions[0].TimestampStr
 		ag.LastMove = mg.Actions[len(mg.Actions)-1].TimestampStr
-		ag.lastMoveTime = mg.Actions[len(mg.Actions)-1].TimeStamp()
 	}
 	ag.Players = make([]ActiveGamePlayer, len(mg.Players))
 	for i, p := range mg.Players {

--- a/network/player_test.go
+++ b/network/player_test.go
@@ -265,13 +265,6 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		resp := ConvertToGetActiveGamesForPlayerResponse(tc.player, tc.inputGames)
-		for i, exp := range tc.expResp.ActiveGames {
-			if exp.LastMove != `` {
-				assert.NotEqual(t, time.Time{}, resp.ActiveGames[i].lastMoveTime)
-				resp.ActiveGames[i].lastMoveTime = time.Time{}
-				tc.expResp.ActiveGames[i].lastMoveTime = time.Time{}
-			}
-		}
 		assert.Equal(t, tc.expResp, resp, tc.desc)
 	}
 }

--- a/network/player_test.go
+++ b/network/player_test.go
@@ -72,8 +72,14 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 	chelseaID := model.PlayerID(`chelsea`)
 	daveID := model.PlayerID(`dave`)
 
+	pa1 := model.PlayerAction{}
+	pa2 := model.PlayerAction{}
+
 	t2 := time.Now()
 	t1 := t2.Add(-time.Minute)
+
+	pa1.SetTimeStamp(t1)
+	pa2.SetTimeStamp(t2)
 
 	tests := []struct {
 		desc       string
@@ -119,9 +125,7 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					aliceID:   model.Red,
 					chelseaID: model.Blue,
 				},
-				Actions: []model.PlayerAction{{
-					TimeStamp: t1,
-				}},
+				Actions: []model.PlayerAction{pa1},
 			},
 			789: {
 				ID: 789,
@@ -136,11 +140,7 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					aliceID: model.Red,
 					daveID:  model.Blue,
 				},
-				Actions: []model.PlayerAction{{
-					TimeStamp: t1,
-				}, {
-					TimeStamp: t2,
-				}},
+				Actions: []model.PlayerAction{pa1, pa2},
 			},
 		},
 		expResp: GetActiveGamesForPlayerResponse{
@@ -159,8 +159,8 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					Name:  `dave`,
 					Color: `blue`,
 				}},
-				Created:  t1,
-				LastMove: t2,
+				Created:  t1.Format(time.RFC3339),
+				LastMove: t2.Format(time.RFC3339),
 			}, {
 				GameID: 456,
 				Players: []ActiveGamePlayer{{
@@ -172,8 +172,8 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					Name:  `chelsea`,
 					Color: `blue`,
 				}},
-				Created:  t1,
-				LastMove: t1,
+				Created:  t1.Format(time.RFC3339),
+				LastMove: t1.Format(time.RFC3339),
 			}, {
 				GameID: 123,
 				Players: []ActiveGamePlayer{{
@@ -185,8 +185,8 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					Name:  `bob`,
 					Color: `blue`,
 				}},
-				Created:  time.Time{},
-				LastMove: time.Time{},
+				Created:  ``,
+				LastMove: ``,
 			}},
 		},
 	}, {
@@ -258,13 +258,19 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 					Name:  `bob`,
 					Color: `blue`,
 				}},
-				Created:  time.Time{},
-				LastMove: time.Time{},
+				Created:  ``,
+				LastMove: ``,
 			}},
 		},
 	}}
 	for _, tc := range tests {
 		resp := ConvertToGetActiveGamesForPlayerResponse(tc.player, tc.inputGames)
+		for i, exp := range tc.expResp.ActiveGames {
+			if exp.LastMove != `` {
+				assert.NotEqual(t, time.Time{}, resp.ActiveGames[i].lastMoveTime)
+				resp.ActiveGames[i].lastMoveTime = time.Time{}
+			}
+		}
 		assert.Equal(t, tc.expResp, resp, tc.desc)
 	}
 }

--- a/network/player_test.go
+++ b/network/player_test.go
@@ -269,6 +269,7 @@ func TestConvertToGetActiveGamesForPlayerResponse(t *testing.T) {
 			if exp.LastMove != `` {
 				assert.NotEqual(t, time.Time{}, resp.ActiveGames[i].lastMoveTime)
 				resp.ActiveGames[i].lastMoveTime = time.Time{}
+				tc.expResp.ActiveGames[i].lastMoveTime = time.Time{}
 			}
 		}
 		assert.Equal(t, tc.expResp, resp, tc.desc)

--- a/server/persistence/mysql/games.go
+++ b/server/persistence/mysql/games.go
@@ -473,7 +473,7 @@ func (g *gameService) getActions(
 		if err != nil {
 			return nil, err
 		}
-		pa.TimeStamp = pair.timestamp
+		pa.SetTimeStamp(pair.timestamp)
 		pas[i] = pa
 	}
 

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -381,7 +381,7 @@ func testSaveGameMultipleTimes(t *testing.T, name dbName, db persistence.DB) {
 	persistenceGameCopy(&gCopy, g)
 
 	require.NoError(t, db.SaveGame(g))
-	checkPersistedGame(t, name, db, gCopy) //
+	checkPersistedGame(t, name, db, gCopy)
 
 	require.NoError(t, play.HandleAction(&g, model.PlayerAction{
 		ID:           alice.ID,

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -143,7 +143,12 @@ func checkPersistedGame(t *testing.T, name dbName, db persistence.DB, expGame mo
 				actGame.Actions[i].TimestampStr,
 				`timestamp should not be empty at index %d`, i,
 			)
+			// now let's clear both the expected and the actual out.
+			// The actual will get re-populated with the mysql entry
+			// so we cannot guarantee that it's exactly the same as
+			// the input timestamp.
 			actGame.Actions[i].TimestampStr = ``
+			expGame.Actions[i].TimestampStr = ``
 		}
 	}
 	assert.Equal(t, expGame, actGame)

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -115,6 +115,12 @@ func checkPersistedGame(t *testing.T, name dbName, db persistence.DB, expGame mo
 		expGame.PeggedCards = nil
 		actGame.PeggedCards = nil
 	}
+	if name == memoryDB {
+		t.Logf("setting games pointers on in-memory players... because memory is weird")
+		for i := range expGame.Players {
+			actGame.Players[i].Games = expGame.Players[i].Games
+		}
+	}
 	if name == memoryDB || name == mongoDB {
 		// memory provider and mongodb do not have this feature implemented
 		t.Logf("clearing out the timestamps from the expected game")

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -3,7 +3,6 @@ package persistence_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -116,10 +115,10 @@ func checkPersistedGame(t *testing.T, name dbName, db persistence.DB, expGame mo
 		expGame.PeggedCards = nil
 		actGame.PeggedCards = nil
 	}
-	for i := range actGame.Actions {
-		if !(name == memoryDB || name == mongoDB) {
-			// memory provider and mongodb do not have this feature implemented
-			assert.NotEqual(t, time.Time{}, actGame.Actions[i].TimeStamp())
+	if name == memoryDB || name == mongoDB {
+		// memory provider and mongodb do not have this feature implemented
+		for i := range actGame.Actions {
+			expGame.Actions[i].TimestampStr = ``
 		}
 	}
 	assert.Equal(t, expGame, actGame)

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -119,9 +119,8 @@ func checkPersistedGame(t *testing.T, name dbName, db persistence.DB, expGame mo
 	for i := range actGame.Actions {
 		if !(name == memoryDB || name == mongoDB) {
 			// memory provider and mongodb do not have this feature implemented
-			assert.NotEqual(t, time.Time{}, actGame.Actions[i].TimeStamp)
+			assert.NotEqual(t, time.Time{}, actGame.Actions[i].TimeStamp())
 		}
-		actGame.Actions[i].TimeStamp = time.Time{}
 	}
 	assert.Equal(t, expGame, actGame)
 }

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -295,7 +295,6 @@ func testCreateGame(t *testing.T, name dbName, db persistence.DB) {
 			model.NewCardFromString(`ad`),
 		},
 	}
-	g1Copy := g1
 
 	for i, p := range g1.Players {
 		require.NoError(t, db.CreatePlayer(p))
@@ -310,12 +309,12 @@ func testCreateGame(t *testing.T, name dbName, db persistence.DB) {
 			}
 		}
 	}
-	var gCopy model.Game
-	persistenceGameCopy(&gCopy, g1)
+	var g1Copy model.Game
+	persistenceGameCopy(&g1Copy, g1)
 
 	require.NoError(t, db.CreateGame(g1))
 
-	checkPersistedGame(t, name, db, gCopy)
+	checkPersistedGame(t, name, db, g1Copy)
 }
 
 func testSaveGameMultipleTimes(t *testing.T, name dbName, db persistence.DB) {

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -116,10 +116,21 @@ func checkPersistedGame(t *testing.T, name dbName, db persistence.DB, expGame mo
 		actGame.PeggedCards = nil
 	}
 	if name == memoryDB || name == mongoDB {
-		t.Logf("clearing out the timestamps from the expected game")
 		// memory provider and mongodb do not have this feature implemented
+		t.Logf("clearing out the timestamps from the expected game")
 		for i := range actGame.Actions {
 			expGame.Actions[i].TimestampStr = ``
+		}
+	} else if name == mysqlDB {
+		// mysql DB populates this field internally, so it should always be non-empty
+		t.Logf("verifying non-empty timestamps")
+		for i := range actGame.Actions {
+			assert.NotEmpty(
+				t,
+				actGame.Actions[i].TimestampStr,
+				`timestamp should not be empty at index %d`, i,
+			)
+			actGame.Actions[i].TimestampStr = ``
 		}
 	}
 	assert.Equal(t, expGame, actGame)

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -86,13 +86,25 @@ func persistenceGameCopy(dst *model.Game, src model.Game) {
 func checkPersistedGame(t *testing.T, name dbName, db persistence.DB, expGame model.Game) {
 	actGame, err := db.GetGame(expGame.ID)
 	require.NoError(t, err, `expected to find game with id "%d"`, expGame.ID)
-	if len(actGame.Crib) == 0 {
+	if len(expGame.Crib) == 0 {
 		expGame.Crib = nil
 		actGame.Crib = nil
 	}
-	if len(actGame.Actions) == 0 {
+	if len(expGame.Actions) == 0 {
 		expGame.Actions = nil
 		actGame.Actions = nil
+	}
+	if len(expGame.PlayerColors) == 0 {
+		expGame.PlayerColors = nil
+		actGame.PlayerColors = nil
+	}
+	if len(expGame.BlockingPlayers) == 0 {
+		expGame.BlockingPlayers = nil
+		actGame.BlockingPlayers = nil
+	}
+	if len(expGame.Hands) == 0 {
+		expGame.Hands = nil
+		actGame.Hands = nil
 	}
 	for i := range actGame.Actions {
 		if !(name == memoryDB || name == mongoDB) {
@@ -272,8 +284,6 @@ func testCreateGame(t *testing.T, name dbName, db persistence.DB) {
 			model.NewCardFromString(`ac`),
 			model.NewCardFromString(`ad`),
 		},
-		PeggedCards: make([]model.PeggedCard, 0, 8),
-		Actions:     []model.PlayerAction{},
 	}
 	g1Copy := g1
 
@@ -721,7 +731,6 @@ func gameTxTest(t *testing.T, databaseName dbName, db1, db2, postCommitDB persis
 			model.NewCardFromString(`ac`),
 			model.NewCardFromString(`ad`),
 		},
-		PeggedCards: make([]model.PeggedCard, 0, 8),
 	}
 	g1Copy := g1
 	for i, p := range g1Copy.Players {

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -87,24 +87,34 @@ func checkPersistedGame(t *testing.T, name dbName, db persistence.DB, expGame mo
 	actGame, err := db.GetGame(expGame.ID)
 	require.NoError(t, err, `expected to find game with id "%d"`, expGame.ID)
 	if len(expGame.Crib) == 0 {
+		assert.Empty(t, actGame.Crib)
 		expGame.Crib = nil
 		actGame.Crib = nil
 	}
 	if len(expGame.Actions) == 0 {
+		assert.Empty(t, actGame.Actions)
 		expGame.Actions = nil
 		actGame.Actions = nil
 	}
 	if len(expGame.PlayerColors) == 0 {
+		assert.Empty(t, actGame.PlayerColors)
 		expGame.PlayerColors = nil
 		actGame.PlayerColors = nil
 	}
 	if len(expGame.BlockingPlayers) == 0 {
+		assert.Empty(t, actGame.BlockingPlayers)
 		expGame.BlockingPlayers = nil
 		actGame.BlockingPlayers = nil
 	}
 	if len(expGame.Hands) == 0 {
+		assert.Empty(t, actGame.Hands)
 		expGame.Hands = nil
 		actGame.Hands = nil
+	}
+	if len(expGame.PeggedCards) == 0 {
+		assert.Empty(t, actGame.PeggedCards)
+		expGame.PeggedCards = nil
+		actGame.PeggedCards = nil
 	}
 	for i := range actGame.Actions {
 		if !(name == memoryDB || name == mongoDB) {

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -310,12 +310,12 @@ func testCreateGame(t *testing.T, name dbName, db persistence.DB) {
 			}
 		}
 	}
+	var gCopy model.Game
+	persistenceGameCopy(&gCopy, g1)
 
 	require.NoError(t, db.CreateGame(g1))
 
-	actGame, err := db.GetGame(g1.ID)
-	require.NoError(t, err, `expected to find game with id "%d"`, g1.ID)
-	assert.Equal(t, g1Copy, actGame)
+	checkPersistedGame(t, name, db, gCopy)
 }
 
 func testSaveGameMultipleTimes(t *testing.T, name dbName, db persistence.DB) {

--- a/server/persistence/persistence_test.go
+++ b/server/persistence/persistence_test.go
@@ -116,6 +116,7 @@ func checkPersistedGame(t *testing.T, name dbName, db persistence.DB, expGame mo
 		actGame.PeggedCards = nil
 	}
 	if name == memoryDB || name == mongoDB {
+		t.Logf("clearing out the timestamps from the expected game")
 		// memory provider and mongodb do not have this feature implemented
 		for i := range actGame.Actions {
 			expGame.Actions[i].TimestampStr = ``


### PR DESCRIPTION
## What broke / What you're adding
I noticed that our unit tests are lacking in some regards. And then I noticed that our timestamps on player actions are balogna. I'd like to clean those up.

## How you did it
Start by updating the `checkPersistedGame` func so that it makes more sense.

Then get rid of the `time.Time` field on the `PlayerAction` struct and replace it with a string - that's all we'll ever need. This means we can serialize to/from json without issues anymore.

## How to test it and how to try to break it
CI updates makes sense.
CI passes.
